### PR TITLE
Fast sync up

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,7 +8,7 @@ case $1 in
       --datadir="/xayax" \
       --port=8000 \
       --zmq_address="tcp://${HOST}:28555" \
-      --enable_pruning=1000 \
+      --max_reorg_depth=1000 \
       "$@"
     ;;
 

--- a/eth/ethchain.cpp
+++ b/eth/ethchain.cpp
@@ -415,6 +415,13 @@ EthChain::AddMovesFromHeightRange (EthRpc& rpc,
     }
 }
 
+uint64_t
+EthChain::GetTipHeight ()
+{
+  EthRpc rpc(endpoint);
+  return AbiDecoder::ParseInt (rpc->eth_blockNumber ());
+}
+
 std::vector<BlockData>
 EthChain::GetBlockRange (const uint64_t start, const uint64_t count)
 {

--- a/eth/ethchain.hpp
+++ b/eth/ethchain.hpp
@@ -93,6 +93,7 @@ public:
 
   void Start () override;
 
+  uint64_t GetTipHeight () override;
   std::vector<BlockData> GetBlockRange (uint64_t start,
                                         uint64_t count) override;
   int64_t GetMainchainHeight (const std::string& hash) override;

--- a/eth/ethchain.hpp
+++ b/eth/ethchain.hpp
@@ -95,6 +95,7 @@ public:
 
   std::vector<BlockData> GetBlockRange (uint64_t start,
                                         uint64_t count) override;
+  int64_t GetMainchainHeight (const std::string& hash) override;
   std::vector<std::string> GetMempool () override;
   bool VerifyMessage (const std::string& msg, const std::string& signature,
                       std::string& addr) override;

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -34,8 +34,6 @@ DEFINE_bool (listen_locally, true,
 DEFINE_string (zmq_address, "",
                "the address to bind the ZMQ publisher to");
 
-DEFINE_int64 (genesis_height, -1,
-              "height from which to start the local chain state");
 DEFINE_int32 (max_reorg_depth, 1'000,
               "maximum supported depth of reorgs");
 
@@ -65,8 +63,6 @@ main (int argc, char* argv[])
         throw std::runtime_error ("--zmq_address must be set");
       if (FLAGS_datadir.empty ())
         throw std::runtime_error ("--datadir must be set");
-      if (FLAGS_genesis_height == -1)
-        throw std::runtime_error ("--genesis_height must be set");
       if (FLAGS_max_reorg_depth < 0)
         throw std::runtime_error ("--max_reorg_depth must not be negative");
 
@@ -75,17 +71,7 @@ main (int argc, char* argv[])
       base.Start ();
 
       xayax::Controller controller(base, FLAGS_datadir);
-
-      /* We use the genesis height passed and determine the associated
-         block hash.  The height must be already deeply confirmed, so it
-         will not be reorged any more.  */
-      const auto genesis = base.GetBlockRange (FLAGS_genesis_height, 1);
-      if (genesis.size () != 1)
-        throw std::runtime_error ("Genesis block is not yet on the base chain");
-      LOG (INFO) << "Using block " << genesis[0].hash << " as genesis block";
-      controller.SetGenesis (genesis[0].hash, FLAGS_genesis_height);
       controller.SetMaxReorgDepth (FLAGS_max_reorg_depth);
-
       controller.SetZmqEndpoint (FLAGS_zmq_address);
       controller.SetRpcBinding (FLAGS_port, FLAGS_listen_locally);
       if (FLAGS_sanity_checks)

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -36,10 +36,9 @@ DEFINE_string (zmq_address, "",
 
 DEFINE_int64 (genesis_height, -1,
               "height from which to start the local chain state");
+DEFINE_int32 (max_reorg_depth, 1'000,
+              "maximum supported depth of reorgs");
 
-DEFINE_int32 (enable_pruning, -1,
-              "if non-negative (including zero), old move data will be pruned"
-              " and only as many blocks as specified will be kept");
 DEFINE_bool (sanity_checks, false,
              "whether or not to run slow sanity checks for testing");
 
@@ -68,6 +67,8 @@ main (int argc, char* argv[])
         throw std::runtime_error ("--datadir must be set");
       if (FLAGS_genesis_height == -1)
         throw std::runtime_error ("--genesis_height must be set");
+      if (FLAGS_max_reorg_depth < 0)
+        throw std::runtime_error ("--max_reorg_depth must not be negative");
 
       xayax::EthChain base(FLAGS_eth_rpc_url, FLAGS_eth_ws_url,
                            FLAGS_accounts_contract);
@@ -83,13 +84,12 @@ main (int argc, char* argv[])
         throw std::runtime_error ("Genesis block is not yet on the base chain");
       LOG (INFO) << "Using block " << genesis[0].hash << " as genesis block";
       controller.SetGenesis (genesis[0].hash, FLAGS_genesis_height);
+      controller.SetMaxReorgDepth (FLAGS_max_reorg_depth);
 
       controller.SetZmqEndpoint (FLAGS_zmq_address);
       controller.SetRpcBinding (FLAGS_port, FLAGS_listen_locally);
       if (FLAGS_sanity_checks)
         controller.EnableSanityChecks ();
-      if (FLAGS_enable_pruning >= 0)
-        controller.EnablePruning (FLAGS_enable_pruning);
 
       controller.Run ();
     }

--- a/eth/rpc-stubs/eth.json
+++ b/eth/rpc-stubs/eth.json
@@ -5,6 +5,11 @@
     "returns": {}
   },
   {
+    "name": "eth_getBlockByHash",
+    "params": ["0x123", false],
+    "returns": {}
+  },
+  {
     "name": "eth_getLogs",
     "params": [{}],
     "returns": []

--- a/eth/tests/Makefile.am
+++ b/eth/tests/Makefile.am
@@ -9,6 +9,7 @@ REGTESTS = \
   block_data.py \
   moves_data.py \
   moves_multi.py \
+  pruning.py \
   verifymessage.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)

--- a/eth/tests/ethtest.py
+++ b/eth/tests/ethtest.py
@@ -23,6 +23,9 @@ class Fixture (testcase.BaseChainFixture):
     parser.add_argument ("--xeth_binary", default="",
                          help="xayax-eth binary to use")
 
+  def getXayaXExtraArgs (self):
+    return []
+
   @contextmanager
   def environment (self):
     with super ().environment ():
@@ -36,8 +39,9 @@ class Fixture (testcase.BaseChainFixture):
       if top_builddir is None:
         top_builddir = "../.."
       xethBin = os.path.join (top_builddir, "eth", "xayax-eth")
+    xethCmd = [xethBin] + self.getXayaXExtraArgs ()
 
-    env = eth.Environment (self.basedir, self.portgen, xethBin)
+    env = eth.Environment (self.basedir, self.portgen, xethCmd)
     return env.run ()
 
   def deployMultiMover (self):

--- a/eth/tests/pruning.py
+++ b/eth/tests/pruning.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2021 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests requests for blocks that have been pruned.
+"""
+
+
+import ethtest
+
+from xayax.testcase import ZmqSubscriber
+
+import jsonrpclib
+
+
+class PruningFixture (ethtest.Fixture):
+
+  def __init__ (self, depth):
+    super ().__init__ ()
+    self.maxReorgDepth = depth
+
+  def getXayaXExtraArgs (self):
+    return ["--max_reorg_depth=%d" % self.maxReorgDepth]
+
+
+if __name__ == "__main__":
+  with PruningFixture (5) as f:
+    sub = ZmqSubscriber (f.zmqCtx, f.env.getXRpcUrl (), "game")
+    sub.subscribe ("game-block-attach")
+    sub.subscribe ("game-block-detach")
+    with sub.run ():
+      xrpc = jsonrpclib.ServerProxy (f.env.getXRpcUrl ())
+
+      base = f.generate (10)
+      _, baseHeight = f.env.getChainTip ()
+      f.assertZmqBlocks (sub, "attach", base)
+      snapshot = f.env.snapshot ()
+
+      branch1 = f.generate (5)
+      f.assertZmqBlocks (sub, "attach", branch1)
+
+      snapshot.restore ()
+      # Make sure we do not regenerate the same branch again.
+      f.sendMove ("p/domob", {})
+      branch2 = f.generate (20)
+      assert branch1[0] != branch2[0]
+      f.assertZmqBlocks (sub, "detach", branch1[::-1])
+      f.assertZmqBlocks (sub, "attach", branch2)
+
+      f.assertEqual (xrpc.getblockhash (height=baseHeight+5), branch2[4])
+      f.assertEqual (xrpc.getblockheader (blockhash=branch2[4])["height"],
+                     baseHeight + 5)
+      f.assertEqual (xrpc.getblockheader (blockhash=branch1[4])["height"],
+                     baseHeight + 5)
+      f.assertRaises (xrpc.getblockhash, height=baseHeight + 21)
+      f.assertRaises (xrpc.getblockheader, blockhash="unknown")
+
+      data = xrpc.game_sendupdates (gameid="game", fromblock=branch1[-1])
+      f.assertEqual (data["steps"], {
+        "detach": 5,
+        "attach": 20,
+      })
+      f.assertEqual (data["toblock"], branch2[-1])
+      f.assertZmqBlocks (sub, "detach", branch1[::-1],
+                         reqtoken=data["reqtoken"])
+      f.assertZmqBlocks (sub, "attach", branch2, reqtoken=data["reqtoken"])
+
+      data = xrpc.game_sendupdates (gameid="game", fromblock=branch2[9])
+      f.assertEqual (data["steps"], {
+        "detach": 0,
+        "attach": 10,
+      })
+      f.assertEqual (data["toblock"], branch2[-1])
+      f.assertZmqBlocks (sub, "attach", branch2[10:], reqtoken=data["reqtoken"])

--- a/src/basechain.hpp
+++ b/src/basechain.hpp
@@ -86,6 +86,11 @@ public:
   }
 
   /**
+   * Returns the block height of the current tip.
+   */
+  virtual uint64_t GetTipHeight () = 0;
+
+  /**
    * Retrieves a slice of blocks with all associated data (block metadata
    * and contained moves) on the main chain from height start (inclusive)
    * onward.  If there are no or fewer than count blocks on the main chain

--- a/src/basechain.hpp
+++ b/src/basechain.hpp
@@ -95,6 +95,12 @@ public:
                                                 uint64_t count) = 0;
 
   /**
+   * Queries for a block by hash, and returns that block's height
+   * if it is known and on the main chain, and -1 otherwise.
+   */
+  virtual int64_t GetMainchainHeight (const std::string& hash) = 0;
+
+  /**
    * Returns the current mempool of pending transactions (the txids),
    * where the order may be significant.  This is used for tracking
    * of pending moves.

--- a/src/chainstate.cpp
+++ b/src/chainstate.cpp
@@ -31,11 +31,6 @@ SetupSchema (Database& db)
       -- for other branches, the integer indicates the branch.
       `branch` INTEGER NOT NULL,
 
-      -- Set to true if the move data and extra data for this block have
-      -- been pruned.  In this case, the block must be on the main chain
-      -- and must never end up on a branch in the future.
-      `pruned` INTEGER NOT NULL,
-
       -- The RNG seed as hex string.
       `rngseed` TEXT NOT NULL,
 
@@ -46,9 +41,6 @@ SetupSchema (Database& db)
       UNIQUE (`branch`, `height`)
 
     );
-
-    CREATE INDEX IF NOT EXISTS `blocks_by_pruned`
-        ON `blocks` (`pruned`, `branch`, `height`);
 
     -- Data of moves for blocks that have not been pruned yet.
     CREATE TABLE IF NOT EXISTS `moves` (
@@ -86,6 +78,29 @@ SetupSchema (Database& db)
 }
 
 /**
+ * Queries for the lowest or highest mainchain block number.
+ */
+int64_t
+GetMainchainHeight (const Database& db, const std::string& order)
+{
+  auto stmt = db.PrepareRo (R"(
+    SELECT `height`
+      FROM `blocks`
+      WHERE `branch` = 0
+      ORDER BY `height` )" + order + R"(
+      LIMIT 1
+  )");
+
+  if (!stmt.Step ())
+    return -1;
+
+  const auto res = stmt.Get<int64_t> (0);
+  CHECK (!stmt.Step ());
+
+  return res;
+}
+
+/**
  * Inserts a block into the database.
  */
 void
@@ -93,8 +108,8 @@ InsertBlock (Database& db, const BlockData& blk, const uint64_t branch)
 {
   auto stmt = db.Prepare (R"(
     INSERT INTO `blocks`
-      (`hash`, `parent`, `height`, `branch`, `pruned`, `rngseed`, `metadata`)
-      VALUES (?1, ?2, ?3, ?4, 0, ?5, ?6)
+      (`hash`, `parent`, `height`, `branch`, `rngseed`, `metadata`)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6)
   )");
   stmt.Bind (1, blk.hash);
   stmt.Bind (2, blk.parent);
@@ -252,21 +267,13 @@ Chainstate::SetChain (const std::string& chain)
 int64_t
 Chainstate::GetTipHeight () const
 {
-  auto stmt = PrepareRo (R"(
-    SELECT `height`
-      FROM `blocks`
-      WHERE `branch` = 0
-      ORDER BY `height` DESC
-      LIMIT 1
-  )");
+  return GetMainchainHeight (*this, "DESC");
+}
 
-  if (!stmt.Step ())
-    return -1;
-
-  const auto res = stmt.Get<int64_t> (0);
-  CHECK (!stmt.Step ());
-
-  return res;
+int64_t
+Chainstate::GetLowestUnprunedHeight () const
+{
+  return GetMainchainHeight (*this, "ASC");
 }
 
 bool
@@ -424,13 +431,12 @@ Chainstate::GetForkBranch (const std::string& hash,
 
       if (!stmt.Step ())
         {
-          /* The block is not known.  This is fine if it was an initial
-             request, but should not happen if we already are iterating
-             a parent branch of the originally requested block.  */
-          CHECK (branch.empty ())
-              << "Parent block " << curHash
-              << " of existing branch is not known";
-          return false;
+          /* The block is not known.  This can mean one of two things:
+             First, if this was the initial request, it simply means that
+             we do not know that block and cannot respond.  Second, if this
+             is the parent of a previous branch, it could be that we reached
+             the main chain but those blocks have been pruned already.  */
+          return !branch.empty ();
         }
 
       const auto curBranch = stmt.Get<uint64_t> (0);
@@ -441,7 +447,7 @@ Chainstate::GetForkBranch (const std::string& hash,
         return true;
 
       stmt = PrepareRo (R"(
-        SELECT `hash`, `parent`, `height`, `rngseed`, `metadata`, `pruned`
+        SELECT `hash`, `parent`, `height`, `rngseed`, `metadata`
           FROM `blocks`
           WHERE `branch` = ?1 AND `height` <= ?2
           ORDER BY `height` DESC
@@ -452,9 +458,6 @@ Chainstate::GetForkBranch (const std::string& hash,
       while (stmt.Step ())
         {
           BlockData blk;
-          CHECK_EQ (stmt.Get<int64_t> (5), 0)
-              << "Block " << blk.hash << " on branch " << curBranch
-              << " is already pruned";
           blk.hash = stmt.Get<std::string> (0);
           blk.parent = stmt.Get<std::string> (1);
           blk.height = stmt.Get<uint64_t> (2);
@@ -501,7 +504,7 @@ Chainstate::Prune (const uint64_t untilHeight)
   auto query = PrepareRo (R"(
     SELECT `hash`
       FROM `blocks`
-      WHERE (NOT `pruned`) AND `branch` = 0 AND `height` <= ?1
+      WHERE `branch` = 0 AND `height` <= ?1
   )");
   query.Bind (1, untilHeight);
 
@@ -519,21 +522,19 @@ Chainstate::Prune (const uint64_t untilHeight)
       )");
       stmt.Bind (1, hash);
       stmt.Execute ();
-
-      stmt = Prepare (R"(
-        UPDATE `blocks`
-          SET `pruned` = 1, `rngseed` = '', `metadata` = NULL
-          WHERE `hash` = ?1
-      )");
-      stmt.Bind (1, hash);
-      stmt.Execute ();
     }
+
+  auto stmt = Prepare (R"(
+    DELETE FROM `blocks`
+      WHERE `branch` = 0 AND `height` <= ?1
+  )");
+  stmt.Bind (1, untilHeight);
+  stmt.Execute ();
 
   upd.Commit ();
 
   LOG_IF (INFO, cnt > 0)
-      << "Pruned extra data for " << cnt
-      << " blocks until height " << untilHeight;
+      << "Pruned " << cnt << " blocks until height " << untilHeight;
 }
 
 void
@@ -555,16 +556,6 @@ Chainstate::SanityCheck () const
     }
   LOG (INFO)
       << "Running sanity check with " << numBlocks << " blocks in the database";
-
-  /* Blocks not on the main chain should not be pruned.  */
-  stmt = PrepareRo (R"(
-    SELECT `hash`, `branch`
-      FROM `blocks`
-      WHERE `pruned` AND `branch` != 0
-  )");
-  CHECK (!stmt.Step ())
-      << "Block " << stmt.Get<std::string> (0)
-      << " is pruned but on branch " << stmt.Get<uint64_t> (1);
 
   /* All branches should have continguous heights, chaining back either
      to a missing block on branch zero (after the genesis) or a block
@@ -613,7 +604,8 @@ Chainstate::SanityCheck () const
 
       /* If this was branch zero, it should end at an unknown / non-existant
          block.  If this was another branch, it should end at a block of
-         a different branch.  */
+         a different branch, or at a pruned block (missing and before the
+         last unpruned height).  */
       stmt = PrepareRo (R"(
         SELECT `branch`, `height`
           FROM `blocks`
@@ -624,11 +616,15 @@ Chainstate::SanityCheck () const
       if (branch == 0)
         CHECK (!stmt.Step ())
             << "Main branch chains to existing block " << expectedParent;
+      else if (!stmt.Step ())
+        {
+          CHECK_LE (lastHeight, GetLowestUnprunedHeight ())
+              << "Branch " << branch
+              << " chains to a non-existing block " << expectedParent
+              << " that is above pruning height";
+        }
       else
         {
-          CHECK (stmt.Step ())
-              << "Branch " << branch
-              << " chains to non-existing block " << expectedParent;
           CHECK_NE (stmt.Get<uint64_t> (0), branch)
               << "Expected end block " << expectedParent
               << " of branch " << branch << " chains back to the same branch";

--- a/src/chainstate_tests.cpp
+++ b/src/chainstate_tests.cpp
@@ -343,6 +343,24 @@ TEST_F (ChainstateTests, ReimportedTip)
   EXPECT_THAT (branch, ElementsAre (GetBlock (c), GetBlock (b)));
 }
 
+TEST_F (ChainstateTests, ImportingExistingTip)
+{
+  const auto genesis = SetGenesis (10);
+  const auto a = AddBlock (genesis);
+  const auto b = AddBlock (a);
+
+  /* We revert back to a as tip, and then import b.  This should work
+     fine, without running into UNIQUE constraint violations in the database
+     (for instance).  */
+
+  std::string oldTip;
+  ASSERT_TRUE (state.SetTip (GetBlock (a), oldTip));
+  state.ImportTip (GetBlock (b));
+
+  EXPECT_EQ (state.GetTipHeight (), 12);
+  EXPECT_EQ (state.GetLowestUnprunedHeight (), 12);
+}
+
 TEST_F (ChainstateTests, ExtraDataAndPruning)
 {
   const auto genesis = SetGenesis (10);

--- a/src/controller.hpp
+++ b/src/controller.hpp
@@ -51,10 +51,11 @@ private:
   bool sanityChecks = false;
 
   /**
-   * If set to something other than -1, pruning of move data in the
-   * chain state is enabled for blocks this far behind the tip.
+   * The maximum depth of a reorg that we support.  We only keep blocks
+   * in the main chain this far behind current tip.  Must be configured with
+   * SetMaxReorgDepth before the Controller is started.
    */
-  int pruning = -1;
+  int maxReorgDepth = -1;
 
   /** Endpoint for the ZMQ server.  */
   std::string zmqAddr;
@@ -137,10 +138,12 @@ public:
   void EnableSanityChecks ();
 
   /**
-   * Turns on pruning of move data for blocks that are a certain depth
-   * behind the tip.
+   * Configures the maximum depth of a supported reorg.  This controls
+   * how many main-chain blocks are kept behind tip during operation, and
+   * where initial syncing will start.  Must be set before the Controller
+   * can be started.
    */
-  void EnablePruning (unsigned depth);
+  void SetMaxReorgDepth (unsigned depth);
 
   /**
    * Marks a given game to be tracked right upon start of the controller.

--- a/src/controller.hpp
+++ b/src/controller.hpp
@@ -34,11 +34,6 @@ private:
   /** Folder for the data directory with local state.  */
   const std::string dataDir;
 
-  /** Hash for the genesis block we use.  */
-  std::string genesisHash;
-  /** Height for our genesis block.  */
-  uint64_t genesisHeight;
-
   /**
    * Set to true if pending tracking is enabled and the base chain supports it.
    */
@@ -107,11 +102,6 @@ public:
   explicit Controller (BaseChain& bc, const std::string& dir);
 
   virtual ~Controller ();
-
-  /**
-   * Configures the genesis block we want to use in the local chain state.
-   */
-  void SetGenesis (const std::string& hash, uint64_t height);
 
   /**
    * Sets up the endpoint where the ZMQ interface should connect.

--- a/src/private/chainstate.hpp
+++ b/src/private/chainstate.hpp
@@ -113,9 +113,9 @@ public:
                       std::vector<BlockData>& branch) const;
 
   /**
-   * Prunes all move and extra data for blocks on the main chain with a height
-   * below the given number (i.e. asserts that those blocks will certainly
-   * not end up on a branch in the future).
+   * Prunes all data of blocks on the main chain at or below the given height.
+   * This in essence asserts that those blocks will certainly not end up on a
+   * reorg in the future.
    */
   void Prune (uint64_t untilHeight);
 

--- a/src/private/chainstate.hpp
+++ b/src/private/chainstate.hpp
@@ -65,7 +65,7 @@ public:
 
   /**
    * Returns the block height of the best chain.  If there is no block
-   * set yet (not even a genesis block), returns -1.
+   * set yet at all, returns -1.
    */
   int64_t GetTipHeight () const;
 
@@ -90,10 +90,17 @@ public:
   bool GetHeightForHash (const std::string& hash, uint64_t& height) const;
 
   /**
-   * Initialises the chain state by importing the genesis block.  This
-   * clears all other data (if any).
+   * Imports the given block as new tip.  This is mainly used for initialisation
+   * with the very first block, but can be done also later on as long as the
+   * new block has larger height than the current tip, as well as all branches
+   * have been resolved properly before.  In other words, the current tip
+   * must be an ancestor of the imported block, although that cannot be
+   * verified.
+   *
+   * This always prunes every mainchain block before the imported one, so that
+   * both GetLowestUnprunedHeight() and GetTipHeight() match the new tip.
    */
-  void Initialise (const BlockData& genesis);
+  void ImportTip (const BlockData& tip);
 
   /**
    * Attaches a new block as best tip.  If the tip cannot be attached (because

--- a/src/private/sync.hpp
+++ b/src/private/sync.hpp
@@ -102,10 +102,9 @@ private:
   /**
    * Tries to retrieve the block at given height from the base chain and import
    * it as new tip in the chain state.  Returns true on success and false if
-   * we failed to get the block.  The genesis block (if any) will be stored in
-   * the vector of blocks.
+   * we failed to get the block.
    */
-  bool RetrieveNewTip (uint64_t height, std::vector<BlockData>& blocks);
+  bool ImportNewTip (uint64_t height);
 
   /**
    * Runs a single update step.  This checks the state of our chain vs

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -121,7 +121,7 @@ Sync::RetrieveGenesis (std::vector<BlockData>& blocks)
   const auto& blk = blocks.front ();
   CHECK_EQ (blk.hash, genesisHash) << "Mismatch in genesis hash";
 
-  chain.Initialise (blk);
+  chain.ImportTip (blk);
   LOG (INFO)
       << "Retrieved genesis block " << genesisHash << " from the base chain";
   return true;

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -376,6 +376,14 @@ TestZmqSubscriber::AwaitMessages (const std::string& cmd, const size_t num)
   return res;
 }
 
+void
+TestZmqSubscriber::ForgetAll ()
+{
+  std::lock_guard<std::mutex> lock(mut);
+  messages.clear ();
+  VLOG (1) << "Forgot all received and not yet expected messages";
+}
+
 /* ************************************************************************** */
 
 } // namespace xayax

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -222,6 +222,26 @@ TestBaseChain::GetBlockRange (const uint64_t start, const uint64_t count)
   return res;
 }
 
+int64_t
+TestBaseChain::GetMainchainHeight (const std::string& hash)
+{
+  std::lock_guard<std::mutex> lock(mut);
+
+  uint64_t height;
+  if (!chain.GetHeightForHash (hash, height))
+    return -1;
+
+  /* The block is known, but we need to verify as well if it is on
+     the main chain.  */
+  std::string mainchainHash;
+  if (!chain.GetHashForHeight (height, mainchainHash))
+    return -1;
+  if (mainchainHash != hash)
+    return -1;
+
+  return height;
+}
+
 std::vector<std::string>
 TestBaseChain::GetMempool ()
 {

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -204,6 +204,15 @@ TestBaseChain::EnablePending ()
   return true;
 }
 
+uint64_t
+TestBaseChain::GetTipHeight ()
+{
+  std::lock_guard<std::mutex> lock(mut);
+  const int64_t height = chain.GetTipHeight ();
+  CHECK_GE (height, 0) << "No genesis has been set yet";
+  return height;
+}
+
 std::vector<BlockData>
 TestBaseChain::GetBlockRange (const uint64_t start, const uint64_t count)
 {

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -105,7 +105,7 @@ TestBaseChain::SetGenesis (const BlockData& blk)
   std::lock_guard<std::mutex> lock(mut);
 
   blocks[blk.hash] = blk;
-  chain.Initialise (blk);
+  chain.ImportTip (blk);
 
   cvNewTip.notify_all ();
 

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -140,6 +140,7 @@ public:
 
   void Start () override;
   bool EnablePending () override;
+  uint64_t GetTipHeight () override;
   std::vector<BlockData> GetBlockRange (uint64_t start,
                                         uint64_t count) override;
   int64_t GetMainchainHeight (const std::string& hash) override;

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -207,6 +207,11 @@ public:
    */
   std::vector<Json::Value> AwaitMessages (const std::string& cmd, size_t num);
 
+  /**
+   * Forgets / ignores all unexpected messages.
+   */
+  void ForgetAll ();
+
 };
 
 } // namespace xayax

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -142,6 +142,7 @@ public:
   bool EnablePending () override;
   std::vector<BlockData> GetBlockRange (uint64_t start,
                                         uint64_t count) override;
+  int64_t GetMainchainHeight (const std::string& hash) override;
   std::vector<std::string> GetMempool () override;
   bool VerifyMessage (const std::string& msg, const std::string& signature,
                       std::string& addr) override;

--- a/src/testutils_tests.cpp
+++ b/src/testutils_tests.cpp
@@ -129,6 +129,22 @@ TEST_F (TestBaseChainTests, GetBlockRange)
   EXPECT_THAT (bc.GetBlockRange (9, 5), ElementsAre ());
 }
 
+TEST_F (TestBaseChainTests, GetMainchainHeight)
+{
+  const auto genesis = bc.SetGenesis (bc.NewGenesis (10));
+  const auto a = bc.SetTip (bc.NewBlock ());
+  const auto b = bc.SetTip (bc.NewBlock ());
+  const auto c = bc.SetTip (bc.NewBlock ());
+  const auto d = bc.SetTip (bc.NewBlock (a.hash));
+
+  EXPECT_EQ (bc.GetMainchainHeight ("foo"), -1);
+  EXPECT_EQ (bc.GetMainchainHeight (genesis.hash), 10);
+  EXPECT_EQ (bc.GetMainchainHeight (a.hash), 11);
+  EXPECT_EQ (bc.GetMainchainHeight (b.hash), -1);
+  EXPECT_EQ (bc.GetMainchainHeight (c.hash), -1);
+  EXPECT_EQ (bc.GetMainchainHeight (d.hash), 12);
+}
+
 /* ************************************************************************** */
 
 } // anonymous namespace

--- a/xayacore/corechain.cpp
+++ b/xayacore/corechain.cpp
@@ -475,6 +475,29 @@ CoreChain::GetBlockRange (const uint64_t start, const uint64_t count)
   return res;
 }
 
+int64_t
+CoreChain::GetMainchainHeight (const std::string& hash)
+{
+  CoreRpc rpc(endpoint);
+
+  try
+    {
+      const auto data = rpc->getblockheader (hash);
+      CHECK (data.isObject ());
+      const auto conf = data["confirmations"];
+      CHECK (conf.isInt64 ());
+      if (conf.asInt64 () == -1)
+        return -1;
+      CHECK_GE (conf.asInt64 (), 0);
+      return data["height"].asUInt64 ();
+    }
+  catch (const jsonrpc::JsonRpcException& exc)
+    {
+      LOG (WARNING) << "RPC error from getblockheader: " << exc.what ();
+      return -1;
+    }
+}
+
 std::vector<std::string>
 CoreChain::GetMempool ()
 {

--- a/xayacore/corechain.cpp
+++ b/xayacore/corechain.cpp
@@ -417,6 +417,14 @@ CoreChain::EnablePending ()
   return true;
 }
 
+uint64_t
+CoreChain::GetTipHeight ()
+{
+  CoreRpc rpc(endpoint);
+  const auto blockchain = rpc->getblockchaininfo ();
+  return blockchain["blocks"].asUInt64 ();
+}
+
 std::vector<BlockData>
 CoreChain::GetBlockRange (const uint64_t start, const uint64_t count)
 {

--- a/xayacore/corechain.hpp
+++ b/xayacore/corechain.hpp
@@ -61,6 +61,7 @@ public:
   void Start () override;
   bool EnablePending () override;
 
+  uint64_t GetTipHeight () override;
   std::vector<BlockData> GetBlockRange (uint64_t start,
                                         uint64_t count) override;
   int64_t GetMainchainHeight (const std::string& hash) override;

--- a/xayacore/corechain.hpp
+++ b/xayacore/corechain.hpp
@@ -63,6 +63,7 @@ public:
 
   std::vector<BlockData> GetBlockRange (uint64_t start,
                                         uint64_t count) override;
+  int64_t GetMainchainHeight (const std::string& hash) override;
   std::vector<std::string> GetMempool () override;
   bool VerifyMessage (const std::string& msg, const std::string& signature,
                       std::string& addr) override;

--- a/xayacore/main.cpp
+++ b/xayacore/main.cpp
@@ -30,8 +30,6 @@ DEFINE_bool (listen_locally, true,
 DEFINE_string (zmq_address, "",
                "the address to bind the ZMQ publisher to");
 
-DEFINE_int64 (genesis_height, -1,
-               "height from which to start the local chain state");
 DEFINE_int32 (max_reorg_depth, 1'000,
               "maximum supported depth of reorgs");
 
@@ -61,8 +59,6 @@ main (int argc, char* argv[])
         throw std::runtime_error ("--zmq_address must be set");
       if (FLAGS_datadir.empty ())
         throw std::runtime_error ("--datadir must be set");
-      if (FLAGS_genesis_height == -1)
-        throw std::runtime_error ("--genesis_height must be set");
       if (FLAGS_max_reorg_depth < 0)
         throw std::runtime_error ("--max_reorg_depth must not be negative");
 
@@ -70,17 +66,7 @@ main (int argc, char* argv[])
       base.Start ();
 
       xayax::Controller controller(base, FLAGS_datadir);
-
-      /* We use the genesis height passed and determine the associated
-         block hash.  The height must be already deeply confirmed, so it
-         will not be reorged any more.  */
-      const auto genesis = base.GetBlockRange (FLAGS_genesis_height, 1);
-      if (genesis.size () != 1)
-        throw std::runtime_error ("Genesis block is not yet on the base chain");
-      LOG (INFO) << "Using block " << genesis[0].hash << " as genesis block";
-      controller.SetGenesis (genesis[0].hash, FLAGS_genesis_height);
       controller.SetMaxReorgDepth (FLAGS_max_reorg_depth);
-
       controller.SetZmqEndpoint (FLAGS_zmq_address);
       controller.SetRpcBinding (FLAGS_port, FLAGS_listen_locally);
       if (FLAGS_pending_moves)

--- a/xayacore/rpc-stubs/core.json
+++ b/xayacore/rpc-stubs/core.json
@@ -32,6 +32,14 @@
     "returns": {}
   },
   {
+    "name": "getblockheader",
+    "params":
+      {
+        "blockhash": "hash"
+      },
+    "returns": {}
+  },
+  {
     "name": "decoderawtransaction",
     "params":
       {

--- a/xayacore/tests/Makefile.am
+++ b/xayacore/tests/Makefile.am
@@ -9,6 +9,7 @@ REGTESTS = \
   block_data.py \
   moves.py \
   pending.py \
+  pruning.py \
   verifymessage.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)

--- a/xayacore/tests/coretest.py
+++ b/xayacore/tests/coretest.py
@@ -27,6 +27,9 @@ class Fixture (testcase.BaseChainFixture):
     parser.add_argument ("--xcore_binary", default="",
                          help="xayax-core binary to use")
 
+  def getXayaXExtraArgs (self):
+    return []
+
   @contextmanager
   def environment (self):
     with super ().environment ():
@@ -41,7 +44,8 @@ class Fixture (testcase.BaseChainFixture):
       if top_builddir is None:
         top_builddir = "../.."
       xcoreBin = os.path.join (top_builddir, "xayacore", "xayax-core")
+    xcoreCmd = [xcoreBin] + self.getXayaXExtraArgs ()
 
     env = core.Environment (self.basedir, self.portgen,
-                            self.args.xayad_binary, xcoreBin)
+                            self.args.xayad_binary, xcoreCmd)
     return env.run ()

--- a/xayacore/tests/coretest.py
+++ b/xayacore/tests/coretest.py
@@ -37,15 +37,19 @@ class Fixture (testcase.BaseChainFixture):
       self.syncBlocks ()
       yield
 
-  def createBaseChain (self):
-    xcoreBin = self.args.xcore_binary
-    if not xcoreBin:
-      top_builddir = os.getenv ("top_builddir")
-      if top_builddir is None:
-        top_builddir = "../.."
-      xcoreBin = os.path.join (top_builddir, "xayacore", "xayax-core")
-    xcoreCmd = [xcoreBin] + self.getXayaXExtraArgs ()
+  def getXCoreBinary (self):
+    if self.args.xcore_binary:
+      return self.args.xcore_binary
 
+    top_builddir = os.getenv ("top_builddir")
+    if top_builddir is None:
+      top_builddir = "../.."
+
+    return os.path.join (top_builddir, "xayacore", "xayax-core")
+
+  def createBaseChain (self):
+    xcoreBin = self.getXCoreBinary ()
+    xcoreCmd = [xcoreBin] + self.getXayaXExtraArgs ()
     env = core.Environment (self.basedir, self.portgen,
                             self.args.xayad_binary, xcoreCmd)
     return env.run ()

--- a/xayacore/tests/pruning.py
+++ b/xayacore/tests/pruning.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2021 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests requests for blocks that have been pruned.
+"""
+
+
+import coretest
+
+from xayax.testcase import ZmqSubscriber
+
+import jsonrpclib
+
+
+class PruningFixture (coretest.Fixture):
+
+  def __init__ (self, depth):
+    super ().__init__ ()
+    self.maxReorgDepth = depth
+
+  def getXayaXExtraArgs (self):
+    return ["--max_reorg_depth=%d" % self.maxReorgDepth]
+
+
+if __name__ == "__main__":
+  with PruningFixture (5) as f:
+    sub = ZmqSubscriber (f.zmqCtx, f.env.getXRpcUrl (), "game")
+    sub.subscribe ("game-block-attach")
+    sub.subscribe ("game-block-detach")
+    with sub.run ():
+      rpc = f.env.createCoreRpc ()
+      xrpc = jsonrpclib.ServerProxy (f.env.getXRpcUrl ())
+
+      base = f.generate (10)
+      _, baseHeight = f.env.getChainTip ()
+      f.assertZmqBlocks (sub, "attach", base)
+
+      branch1 = f.generate (5)
+      f.assertZmqBlocks (sub, "attach", branch1)
+
+      rpc.invalidateblock (branch1[0])
+      branch2 = f.generate (20)
+      f.assertZmqBlocks (sub, "detach", branch1[::-1])
+      f.assertZmqBlocks (sub, "attach", branch2)
+
+      f.assertEqual (xrpc.getblockhash (height=baseHeight+5), branch2[4])
+      f.assertEqual (xrpc.getblockheader (blockhash=branch2[4])["height"],
+                     baseHeight + 5)
+      f.assertEqual (xrpc.getblockheader (blockhash=branch1[4])["height"],
+                     baseHeight + 5)
+      f.assertRaises (xrpc.getblockhash, height=baseHeight + 21)
+      f.assertRaises (xrpc.getblockheader, blockhash="unknown")
+
+      data = xrpc.game_sendupdates (gameid="game", fromblock=branch1[-1])
+      f.assertEqual (data["steps"], {
+        "detach": 5,
+        "attach": 20,
+      })
+      f.assertEqual (data["toblock"], branch2[-1])
+      f.assertZmqBlocks (sub, "detach", branch1[::-1],
+                         reqtoken=data["reqtoken"])
+      f.assertZmqBlocks (sub, "attach", branch2, reqtoken=data["reqtoken"])
+
+      data = xrpc.game_sendupdates (gameid="game", fromblock=branch2[9])
+      f.assertEqual (data["steps"], {
+        "detach": 0,
+        "attach": 10,
+      })
+      f.assertEqual (data["toblock"], branch2[-1])
+      f.assertZmqBlocks (sub, "attach", branch2[10:], reqtoken=data["reqtoken"])

--- a/xayax/core.py
+++ b/xayax/core.py
@@ -71,7 +71,6 @@ class Instance:
     args.append ("--port=%d" % self.port)
     args.append ("--zmq_address=tcp://127.0.0.1:%d" % self.zmqPort)
     args.append ("--datadir=%s" % self.datadir)
-    args.append ("--genesis_height=0")
     args.append ("--sanity_checks")
     envVars = dict (os.environ)
     envVars["GLOG_log_dir"] = self.datadir

--- a/xayax/core.py
+++ b/xayax/core.py
@@ -28,7 +28,7 @@ class Instance:
   most likely be used.
   """
 
-  def __init__ (self, basedir, portgen, binary):
+  def __init__ (self, basedir, portgen, binary, dirname="xayax-core"):
     """
     Initialises / configures a fresh instance without starting it.
     portgen should be a generator that yields free ports for using
@@ -36,7 +36,7 @@ class Instance:
     """
 
     self.log = logging.getLogger ("xayax.core")
-    self.datadir = os.path.join (basedir, "xayax-core")
+    self.datadir = os.path.join (basedir, dirname)
     self.binary = binary
 
     self.port = next (portgen)

--- a/xayax/eth.py
+++ b/xayax/eth.py
@@ -116,7 +116,6 @@ class Instance:
     args.append ("--port=%d" % self.port)
     args.append ("--zmq_address=tcp://127.0.0.1:%d" % self.zmqPort)
     args.append ("--datadir=%s" % self.datadir)
-    args.append ("--genesis_height=0")
     args.append ("--sanity_checks")
     envVars = dict (os.environ)
     envVars["GLOG_log_dir"] = self.datadir

--- a/xayax/testcase.py
+++ b/xayax/testcase.py
@@ -241,6 +241,19 @@ class Fixture:
     self.log.error ("The value of:\n%s\n\nis not equal to:\n%s" % (a, b))
     raise AssertionError ("%s != %s" % (a, b))
 
+  def assertRaises (self, fcn, *args, **kwargs):
+    """
+    Asserts that the given call throws an exception.
+    """
+
+    try:
+      fcn (*args, **kwargs)
+      raise AssertionError ("Call did not throw as expected")
+    except AssertionError:
+      raise
+    except:
+      pass
+
   def assertZmqBlocks (self, sub, typ, hashes, reqtoken=None):
     """
     Receives messages on the ZMQ subscriber, expecting attach/detach messages


### PR DESCRIPTION
This implements #2:  Instead of removing just "extra data" (like moves) when pruning, we now completely remove all traces of pruned blocks from the local database.  This saves a lot of space on chains with lots of blocks like Polygon, and allows running a Xaya X instance even for them with just a few megabytes of disk space.  Since "old" main-chain blocks can be requested from the base-chain on demand any time they are needed, that is something we can easily do.

As a consequence, we also don't even need to process all those blocks.  Instead, we can just start syncing from a bit behind the current base-chain tip.  And if Xaya X is restarted after being offline for some time, it can "fast catch-up" by just resolving any branches it may have been on, and then directly importing a recent block from the base chain.  This makes also syncing much faster (almost non-existant), and thus Xaya X becomes a really light-weight layer on top of the base blockchain.  As an added benefit, there is now no longer the concept of a "genesis height" and the need to configure any.