### PR TITLE
Handle base-chain errors properly

### DIFF
--- a/src/basechain.hpp
+++ b/src/basechain.hpp
@@ -19,6 +19,9 @@ namespace xayax
  * Interface that the "base chain" connector needs to implement to provide
  * Xaya X with the raw data on the connected blockchain.  The implemented
  * methods by subclasses may be called in parallel and should be thread-safe.
+ *
+ * The implementation methods may throw exceptions, and the code inside Xaya X
+ * using them must gracefully handle them.
  */
 class BaseChain
 {

--- a/src/sync_tests.cpp
+++ b/src/sync_tests.cpp
@@ -7,6 +7,7 @@
 #include "private/chainstate.hpp"
 #include "testutils.hpp"
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
@@ -17,6 +18,9 @@
 
 namespace xayax
 {
+
+DECLARE_int32 (xayax_update_timeout_ms);
+
 namespace
 {
 
@@ -214,6 +218,10 @@ TEST_F (SyncTests, InitialBlock)
 
 TEST_F (SyncTests, BasicSyncing)
 {
+  /* Make sure we use a long / "real" update time out, so that we can ensure
+     it is not actually used.  */
+  FLAGS_xayax_update_timeout_ms = 10'000;
+
   base.SetGenesis (base.NewGenesis (0));
   base.SetTip (base.NewBlock ());
   auto blk = base.SetTip (base.NewBlock ());
@@ -275,6 +283,9 @@ TEST_F (SyncTests, FastCatchup)
 
 TEST_F (SyncTests, DiscoversNewBlocks)
 {
+  /* Use a smaller update timeout to speed up the test.  */
+  FLAGS_xayax_update_timeout_ms = 100;
+
   base.SetGenesis (base.NewGenesis (0));
   StartSync (0);
 

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -62,6 +62,14 @@ TestBaseChain::NewBlockHash ()
   return res.str ();
 }
 
+void
+TestBaseChain::MaybeThrow ()
+{
+  std::lock_guard<std::mutex> lock(mut);
+  if (shouldThrow)
+    throw std::runtime_error ("simulated base-chain error");
+}
+
 BlockData
 TestBaseChain::NewGenesis (const uint64_t h)
 {
@@ -167,6 +175,13 @@ TestBaseChain::SetVersion (const uint64_t v)
 }
 
 void
+TestBaseChain::SetShouldThrow (const bool v)
+{
+  std::lock_guard<std::mutex> lock(mut);
+  shouldThrow = v;
+}
+
+void
 TestBaseChain::Start ()
 {
   std::lock_guard<std::mutex> lock(mut);
@@ -207,6 +222,7 @@ TestBaseChain::EnablePending ()
 uint64_t
 TestBaseChain::GetTipHeight ()
 {
+  MaybeThrow ();
   std::lock_guard<std::mutex> lock(mut);
   const int64_t height = chain.GetTipHeight ();
   CHECK_GE (height, 0) << "No genesis has been set yet";
@@ -216,6 +232,7 @@ TestBaseChain::GetTipHeight ()
 std::vector<BlockData>
 TestBaseChain::GetBlockRange (const uint64_t start, const uint64_t count)
 {
+  MaybeThrow ();
   std::lock_guard<std::mutex> lock(mut);
   std::vector<BlockData> res;
 
@@ -234,6 +251,7 @@ TestBaseChain::GetBlockRange (const uint64_t start, const uint64_t count)
 int64_t
 TestBaseChain::GetMainchainHeight (const std::string& hash)
 {
+  MaybeThrow ();
   std::lock_guard<std::mutex> lock(mut);
 
   uint64_t height;
@@ -254,6 +272,7 @@ TestBaseChain::GetMainchainHeight (const std::string& hash)
 std::vector<std::string>
 TestBaseChain::GetMempool ()
 {
+  MaybeThrow ();
   std::lock_guard<std::mutex> lock(mut);
   return mempool;
 }
@@ -268,6 +287,7 @@ TestBaseChain::VerifyMessage (const std::string& msg,
 std::string
 TestBaseChain::GetChain ()
 {
+  MaybeThrow ();
   std::lock_guard<std::mutex> lock(mut);
   return chainString;
 }
@@ -275,6 +295,7 @@ TestBaseChain::GetChain ()
 uint64_t
 TestBaseChain::GetVersion ()
 {
+  MaybeThrow ();
   std::lock_guard<std::mutex> lock(mut);
   return version;
 }

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -80,10 +80,18 @@ private:
   /** The version number to return.  */
   uint64_t version = 0;
 
+  /** If set to true, then implementation methods throw.  */
+  bool shouldThrow = false;
+
   /**
    * Constructs a new block hash based on our counter.
    */
   std::string NewBlockHash ();
+
+  /**
+   * Checks if shouldThrow is true, and throws if it is.
+   */
+  void MaybeThrow ();
 
 public:
 
@@ -137,6 +145,11 @@ public:
    * Sets the version number to return.
    */
   void SetVersion (uint64_t v);
+
+  /**
+   * Turns errors to be thrown by implementation methods on or off.
+   */
+  void SetShouldThrow (bool v);
 
   void Start () override;
   bool EnablePending () override;

--- a/xayacore/tests/Makefile.am
+++ b/xayacore/tests/Makefile.am
@@ -6,6 +6,7 @@ TEST_LIBRARY = coretest.py
 
 REGTESTS = \
   attach_detach.py \
+  basechain_errors.py \
   block_data.py \
   moves.py \
   pending.py \

--- a/xayacore/tests/basechain_errors.py
+++ b/xayacore/tests/basechain_errors.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2021 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests that temporary errors in the base-chain connection are handled
+gracefully.
+"""
+
+
+import coretest
+
+from xayax.testcase import ZmqSubscriber
+
+import jsonrpclib
+
+import time
+
+
+class FastUpdateFixture (coretest.Fixture):
+  """
+  Extended fixture class that sets a smaller update-timeout value
+  for Xaya X so the test runs faster (even if we wait for multiple
+  timeouts to occur).
+  """
+
+  # The reduced update timeout value we use in ms.
+  TIMEOUT_MS = 100
+
+  def getXayaXExtraArgs (self):
+    return ["--xayax_update_timeout_ms=%d" % self.TIMEOUT_MS]
+
+
+def runTest (f, errorFcn):
+  """
+  Runs one instance of the test in the given fixture.  The errorFcn
+  is invoked to temporarily break the RPC proxy, i.e. defines what
+  type of error the test simulates.
+  """
+
+  sub = ZmqSubscriber (f.zmqCtx, f.env.getXRpcUrl (), "game")
+  sub.subscribe ("game-block-attach")
+  sub.subscribe ("game-block-detach")
+
+  with sub.run ():
+    rpc = f.env.createCoreRpc ()
+    xrpc = jsonrpclib.ServerProxy (f.env.getXRpcUrl ())
+
+    base = f.generate (10)
+    branch1 = f.generate (10)
+    f.waitForZmqTip (sub, branch1[-1])
+
+    # Break the base-chain RPC temporarily.  Then we wait at least for
+    # some forced updates to happen (to make sure they are handled gracefully
+    # even with errors), update the base chain to a new branch, fix up the
+    # RPC and wait for the sync to catch back on.
+    f.log.info ("Turning on RPC breakage now")
+    errorFcn ()
+    rpc.invalidateblock (branch1[0])
+    branch2 = f.generate (5)
+    time.sleep (2e-3 * f.TIMEOUT_MS)
+
+    # TODO: Also test RPC commands (e.g. game_sendupdates and requesting
+    # the chain state directly).
+
+    f.log.info ("Restoring RPC connection")
+    f.env.proxy.fixup ()
+    f.assertZmqBlocks (sub, "detach", branch1[::-1])
+    f.assertZmqBlocks (sub, "attach", branch2)
+
+
+if __name__ == "__main__":
+  with FastUpdateFixture () as f:
+    f.mainLogger.info ("Testing disconnected base-chain RPC...")
+    runTest (f, f.env.proxy.stop)
+  with FastUpdateFixture () as f:
+    f.mainLogger.info ("Testing base-chain HTTP errors...")
+    runTest (f, f.env.proxy.enableHttpErrors)
+  with FastUpdateFixture () as f:
+    f.mainLogger.info ("Testing base-chain RPC errors...")
+    runTest (f, f.env.proxy.enableRpcErrors)

--- a/xayax/rpcproxy.py
+++ b/xayax/rpcproxy.py
@@ -1,0 +1,161 @@
+# Copyright (C) 2021 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Simple proxy server for JSON-RPC, which just forwards requests to
+another host/port.  It has the ability to disconnect and reconnect
+on demand, and to toggle on returning errors.  This allows easily
+testing situations where e.g. the basechain of Xaya X throws intermittend
+failures.
+"""
+
+import requests
+
+import contextlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import logging
+import threading
+
+
+class RequestHandler (BaseHTTPRequestHandler):
+  """
+  Request handler that just forwards POST requests to another host/port,
+  or returns a fixed error.
+  """
+
+  def do_POST (self):
+    request = self.rfile.read (int (self.headers["Content-Length"]))
+    data = json.loads (request)
+
+    with self.server.lock:
+      errors = self.server.returnErrors
+
+    if errors == "http":
+      self.send_error (500, explain="Faked HTTP error")
+      return
+
+    if errors == "rpc":
+      result = {
+        "jsonrpc": "2.0",
+        "id": data["id"],
+        "error": {
+          "code": -32_000,
+          "message": "Faked RPC error",
+        },
+      }
+    else:
+      assert errors is None, "unexpected error request: %s" % errors
+      resp = requests.post (self.server.targetUrl, json=data)
+      if resp.status_code != 200:
+        self.send_error (resp.status_code)
+        return
+      result = resp.json ()
+
+    body = json.dumps (result).encode ("ascii")
+    self.send_response (200)
+    self.send_header ("Content-Length", str (len (body)))
+    self.send_header ("Content-Type", "application/json")
+    self.end_headers ()
+    self.wfile.write (body)
+
+  def log_message (self, fmt, *args):
+    pass
+
+
+class Proxy:
+  """
+  The main proxy class, which can be run as a server and then forwards
+  requests.  It can be stopped/started at will and instructed to return
+  faked errors for testing.
+  """
+
+  def __init__ (self, addr, targetUrl):
+    self.log = logging.getLogger ("xayax.rpcproxy")
+    self.address = addr
+    self.targetUrl = targetUrl
+    self.log.info ("RPC proxy is listening at %s:%d and calls %s"
+                      % (addr[0], addr[1], self.targetUrl))
+
+    # This class does not inherit from the HTTPServer class directly, but
+    # instead uses an internal instance.  This allows us to properly start
+    # and stop the server on demand.
+    self.server = None
+    self.runner = None
+
+  def start (self):
+    """
+    Starts the server in a background thread.
+    """
+
+    assert not self.server, "server is already running"
+    self.log.info ("Starting RPC proxy server")
+
+    self.server = ThreadingHTTPServer (self.address, RequestHandler)
+    self.server.targetUrl = self.targetUrl
+    self.server.returnErrors = None
+    self.server.lock = threading.Lock ()
+
+    self.runner = threading.Thread (target=self.server.serve_forever)
+    self.runner.start ()
+
+  def stop (self):
+    """
+    Stops the running server.
+    """
+
+    assert self.server, "server is not running"
+    self.server.shutdown ()
+    self.runner.join ()
+    self.runner = None
+    self.server.server_close ()
+    self.server = None
+    self.log.info ("Stopped RPC proxy server")
+
+  def setErrors (self, typ):
+    assert self.server, "server is not running"
+    with self.server.lock:
+      self.server.returnErrors = typ
+
+  def enableRpcErrors (self):
+    """
+    Makes the server return RPC errors to requests.
+    """
+
+    self.log.info ("Turning on RPC errors in the proxy server")
+    self.setErrors ("rpc")
+
+  def enableHttpErrors (self):
+    """
+    Makes the server return HTTP errors to requests.
+    """
+
+    self.log.info ("Turning on HTTP errors in the proxy server")
+    self.setErrors ("http")
+
+  def fixup (self):
+    """
+    Makes the server forward requests normally again.  This starts it if it
+    has been stopped, and turns off error returning.
+    """
+
+    self.log.info ("Fixing up proxy server")
+
+    if not self.server:
+      self.start ()
+
+    self.setErrors (None)
+
+  @contextlib.contextmanager
+  def run (self):
+    """
+    Runs the server normally.
+    """
+
+    self.start ()
+    try:
+      yield self
+    finally:
+      if self.server:
+        self.stop ()

--- a/xayax/testcase.py
+++ b/xayax/testcase.py
@@ -156,6 +156,7 @@ class Fixture:
     rootLogger = logging.getLogger ()
     rootLogger.setLevel (logging.INFO)
     rootLogger.addHandler (logHandler)
+    self.rootHandlers = [logHandler]
 
     self.log = logging.getLogger ("xayax.testcase")
 
@@ -165,6 +166,7 @@ class Fixture:
     self.mainLogger = logging.getLogger ("main")
     self.mainLogger.addHandler (logHandler)
     self.mainLogger.addHandler (mainHandler)
+    self.mainHandlers = [logHandler, mainHandler]
     self.mainLogger.info ("Base directory for integration test: %s"
                             % self.basedir)
 
@@ -205,7 +207,10 @@ class Fixture:
       else:
         cleanup = True
 
-    logging.shutdown ()
+    for h in self.rootHandlers:
+      logging.getLogger ().removeHandler (h)
+    for h in self.mainHandlers:
+      self.mainLogger.removeHandler (h)
 
     if cleanup:
       shutil.rmtree (self.basedir, ignore_errors=True)


### PR DESCRIPTION
This set of commits introduces proper error handling for issues with the `BaseChain` methods.  They are now explicitly allowed to throw exceptions (e.g. if the underlying base-chain RPC has temporary issues), and most of the Xaya X code will gracefully handle this.  Sync will just retry in the next step (so once the errors go away, it will ultimately catch back up), and RPCs will re-raise the errors as JSON-RPC errors to the caller.