### PR TITLE
Introduce "mvid" for EthChain

### DIFF
--- a/eth/ethchain.cpp
+++ b/eth/ethchain.cpp
@@ -9,7 +9,6 @@
 
 #include "rpc-stubs/ethrpcclient.h"
 
-#include <eth-utils/abi.hpp>
 #include <eth-utils/address.hpp>
 
 #include <jsonrpccpp/client.h>
@@ -110,11 +109,21 @@ ExtractBaseData (const Json::Value& val)
 MoveData
 ExtractMove (const Json::Value& val)
 {
-  MoveData res;
+  AbiDecoder dec(val["data"].asString ());
+  MoveData res = GetMoveDataFromLogs (dec);
   res.txid = ConvertUint256 (val["transactionHash"].asString ());
+
+  return res;
+}
+
+} // anonymous namespace
+
+MoveData
+GetMoveDataFromLogs (AbiDecoder& dec)
+{
+  MoveData res;
   res.metadata = Json::Value (Json::objectValue);
 
-  AbiDecoder dec(val["data"].asString ());
   res.ns = dec.ReadString ();
   res.name = dec.ReadString ();
   res.mv = dec.ReadString ();
@@ -136,8 +145,6 @@ ExtractMove (const Json::Value& val)
 
   return res;
 }
-
-} // anonymous namespace
 
 /* ************************************************************************** */
 

--- a/eth/ethchain.hpp
+++ b/eth/ethchain.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 The Xaya developers
+// Copyright (C) 2021-2022 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,12 +9,19 @@
 
 #include "basechain.hpp"
 
+#include <eth-utils/abi.hpp>
 #include <eth-utils/ecdsa.hpp>
 
 #include <memory>
 
 namespace xayax
 {
+
+/**
+ * Extracts the data for one move from the logs data.  The txid is not
+ * part of the logs and not added to MoveData by this method.
+ */
+MoveData GetMoveDataFromLogs (ethutils::AbiDecoder& dec);
 
 /**
  * BaseChain connector that links to an Ethereum-like network endpoing.

--- a/eth/tests/moves_multi.py
+++ b/eth/tests/moves_multi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2021 The Xaya developers
+# Copyright (C) 2021-2022 The Xaya developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -11,6 +11,8 @@ transaction (with a custom contract).
 
 
 import ethtest
+
+from moves_data import mvid
 
 from xayax.eth import uintToXaya
 from xayax.testcase import ZmqSubscriber
@@ -63,30 +65,35 @@ if __name__ == "__main__":
         {
           "txid": ids[1],
           "cmd": 1,
+          "mvid": mvid (f, "g", "game", 0),
           "burnt": 0,
           "out": {},
         },
         {
           "txid": ids[3],
           "cmd": 2,
+          "mvid": mvid (f, "g", "game", 1),
           "burnt": 0,
           "out": {},
         },
         {
           "txid": ids[4],
           "cmd": 3,
+          "mvid": mvid (f, "g", "game", 2),
           "burnt": 0,
           "out": {},
         },
         {
           "txid": ids[4],
           "cmd": 4,
+          "mvid": mvid (f, "g", "game", 3),
           "burnt": 0,
           "out": {},
         },
         {
           "txid": ids[6],
           "cmd": 100,
+          "mvid": mvid (f, "g", "game", 4),
           "burnt": 0,
           "out": {},
         },
@@ -96,6 +103,7 @@ if __name__ == "__main__":
           "txid": ids[0],
           "name": "domob",
           "move": 1,
+          "mvid": mvid (f, "p", "domob", 0),
           "burnt": 0,
           "out": {},
         },
@@ -103,6 +111,7 @@ if __name__ == "__main__":
           "txid": ids[2],
           "name": "game",
           "move": 2,
+          "mvid": mvid (f, "p", "game", 0),
           "burnt": 0,
           "out": {},
         },
@@ -110,6 +119,7 @@ if __name__ == "__main__":
           "txid": ids[2],
           "name": "game",
           "move": 3,
+          "mvid": mvid (f, "p", "game", 1),
           "burnt": 0,
           "out": {},
         },
@@ -117,6 +127,7 @@ if __name__ == "__main__":
           "txid": ids[2],
           "name": "domob",
           "move": 2,
+          "mvid": mvid (f, "p", "domob", 1),
           "burnt": 0,
           "out": {},
         },
@@ -124,6 +135,7 @@ if __name__ == "__main__":
           "txid": ids[2],
           "name": "domob",
           "move": 3,
+          "mvid": mvid (f, "p", "domob", 2),
           "burnt": 0,
           "out": {},
         },
@@ -131,6 +143,7 @@ if __name__ == "__main__":
           "txid": ids[3],
           "name": "game",
           "move": 4,
+          "mvid": mvid (f, "p", "game", 2),
           "burnt": 0,
           "out": {},
         },
@@ -138,6 +151,7 @@ if __name__ == "__main__":
           "txid": ids[5],
           "name": "domob",
           "move": 42,
+          "mvid": mvid (f, "p", "domob", 3),
           "burnt": 0,
           "out": {},
         },


### PR DESCRIPTION
On EVM-based chains, moves can be triggered by smart contracts.  This has the consequence that a single transaction and txid is no longer directly associated to a "unique" move, but could trigger multiple moves, or it could trigger different moves depending on the context (like contract states) during reorgs.

Hence, the `txid` is no longer a viable identifier for moves, as it is on Xaya Core (for instance, to generate channel IDs or reinits).  This change adds a new concept `mvid`, which is returned with move JSON by `EthChain`.  It is the Keccak hash of the ABI-encoded logs data from the `Move` event for each move.  As such, it commits to ns/name/nonce (making it necessarily unique among a particular chain history), as well as to key data like the move string or WCHI payments.

This new mvid is thus very similar in properties to the txid on Xaya Core, and can be used as alternative as needed.  Note that it is not a perfectly unique representation of a particular move and context (just like the txid is not).  But if that is needed, it can be hashed together with its containing block hash.