### PR TITLE
Optional block caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ test-driver
 Makefile
 Makefile.in
 __pycache__
+.dirstamp
 
 *.lo
 *.la

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,7 @@ AX_PKG_CHECK_MODULES([XAYAUTIL], [], [libxayautil])
 AX_PKG_CHECK_MODULES([JSONRPCCLIENT], [], [libjsonrpccpp-client])
 AX_PKG_CHECK_MODULES([JSONRPCSERVER], [], [libjsonrpccpp-server])
 AX_PKG_CHECK_MODULES([GLOG], [], [libglog])
+AX_PKG_CHECK_MODULES([PROTOBUF], [], [protobuf])
 AX_PKG_CHECK_MODULES([SQLITE3], [], [sqlite3])
 AX_PKG_CHECK_MODULES([UNIVALUE], [], [libunivalue])
 # We use the recv variant taking message_t& over deprecated older functions,

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,8 @@ AX_PKG_CHECK_MODULES([GLOG], [], [libglog])
 AX_PKG_CHECK_MODULES([PROTOBUF], [], [protobuf])
 AX_PKG_CHECK_MODULES([SQLITE3], [], [sqlite3])
 AX_PKG_CHECK_MODULES([UNIVALUE], [], [libunivalue])
+AX_PKG_CHECK_MODULES([MYPP], [], [mypp])
+AX_PKG_CHECK_MODULES([MARIADB], [], [mariadb])
 # We use the recv variant taking message_t& over deprecated older functions,
 # which requires at least version 4.3.1.
 AX_PKG_CHECK_MODULES([ZMQ], [], [libzmq >= 4.3.1])

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN apk add --no-cache \
   git \
   gflags-dev \
   libtool \
+  mariadb-dev \
   npm \
   pkgconfig \
   py3-pip \
@@ -53,6 +54,13 @@ ARG ETHUTILS_VERSION="master"
 WORKDIR /usr/src/ethutils
 RUN git clone -b ${ETHUTILS_VERSION} \
   https://github.com/xaya/eth-utils .
+RUN ./autogen.sh && ./configure && make && make install-strip
+
+# Build and install mypp.
+ARG MYPP_VERSION="master"
+WORKDIR /usr/src/mypp
+RUN git clone -b ${MYPP_VERSION} \
+  https://github.com/xaya/mypp .
 RUN ./autogen.sh && ./configure && make && make install-strip
 
 # Build and install Xaya X itself.  Make sure to clean out any

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -1,9 +1,10 @@
-// Copyright (C) 2021 The Xaya developers
+// Copyright (C) 2021-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "config.h"
 
+#include "blockcache.hpp"
 #include "controller.hpp"
 
 #include "ethchain.hpp"
@@ -42,6 +43,9 @@ DEFINE_string (watch_for_pending_moves, "",
                " for pending moves");
 DEFINE_bool (sanity_checks, false,
              "whether or not to run slow sanity checks for testing");
+
+DEFINE_bool (blockcache_memory, false,
+             "if enabled, cache blocks in memory (useful for testing)");
 
 /**
  * Parses the comma-separated list of addresses and adds them to the
@@ -94,7 +98,26 @@ main (int argc, char* argv[])
                            FLAGS_accounts_contract);
       base.Start ();
 
-      xayax::Controller controller(base, FLAGS_datadir);
+      std::unique_ptr<xayax::BlockCacheChain::Storage> cacheStore;
+      if (FLAGS_blockcache_memory)
+        {
+          if (cacheStore != nullptr)
+            throw std::runtime_error ("only one block cache can be chosen");
+          cacheStore = std::make_unique<xayax::InMemoryBlockStorage> ();
+          LOG (WARNING)
+              << "Using in-memory block cache,"
+                 " which should be used only for testing";
+        }
+      std::unique_ptr<xayax::BlockCacheChain> cache;
+      if (cacheStore != nullptr)
+        cache = std::make_unique<xayax::BlockCacheChain> (
+                    base, *cacheStore, FLAGS_max_reorg_depth);
+
+      xayax::BaseChain* baseOrCache = &base;
+      if (cache != nullptr)
+        baseOrCache = cache.get ();
+
+      xayax::Controller controller(*baseOrCache, FLAGS_datadir);
       controller.SetMaxReorgDepth (FLAGS_max_reorg_depth);
       controller.SetZmqEndpoint (FLAGS_zmq_address);
       controller.SetRpcBinding (FLAGS_port, FLAGS_listen_locally);

--- a/eth/tests/Makefile.am
+++ b/eth/tests/Makefile.am
@@ -6,6 +6,7 @@ TEST_LIBRARY = ethtest.py
 
 REGTESTS = \
   attach_detach.py \
+  blockcache.py \
   block_data.py \
   moves_data.py \
   moves_multi.py \

--- a/eth/tests/blockcache.py
+++ b/eth/tests/blockcache.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests that Xaya X runs and works with the (in memory) block cache enabled.
+"""
+
+
+import ethtest
+
+from xayax.testcase import ZmqSubscriber
+
+import jsonrpclib
+
+
+class MemoryCacheFixture (ethtest.Fixture):
+  """
+  Test fixture that runs Xaya X with an in-memory block cache enabled
+  and a given max reorg depth (which also affects which blocks get cached).
+  """
+
+  def __init__ (self, depth, blockRange):
+    super ().__init__ ()
+    self.depth = depth
+    self.blockRange = blockRange
+
+  def getXayaXExtraArgs (self):
+    return [
+        "--blockcache_memory",
+        "--max_reorg_depth=%d" % self.depth,
+        "--xayax_block_range=%d" % self.blockRange,
+    ]
+
+
+if __name__ == "__main__":
+  with MemoryCacheFixture (depth=5, blockRange=3) as f:
+    sub = ZmqSubscriber (f.zmqCtx, f.env.getXRpcUrl (), "game")
+    sub.subscribe ("game-block-attach")
+    with sub.run ():
+      xrpc = jsonrpclib.ServerProxy (f.env.getXRpcUrl ())
+
+      blocks = f.generate (20)
+      f.assertZmqBlocks (sub, "attach", blocks)
+
+      # Request multiple times the blocks.  This will use a cache for the
+      # earlier steps and in the later requests (but all should return
+      # the correct set of blocks in the end).
+      for _ in range (5):
+        startInd = 0
+        while True:
+          data = xrpc.game_sendupdates (gameid="game",
+                                        fromblock=blocks[startInd])
+          f.assertEqual (data["steps"]["detach"], 0)
+          endInd = startInd + data["steps"]["attach"]
+          f.assertZmqBlocks (sub, "attach", blocks[startInd + 1 : endInd + 1],
+                             reqtoken=data["reqtoken"])
+          if data["toblock"] == blocks[-1]:
+            f.assertEqual (endInd + 1, len (blocks))
+            break
+          startInd = endInd

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,17 +18,20 @@ libxayax_la_CXXFLAGS = \
   $(XAYAUTIL_CFLAGS) \
   $(JSONCPP_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
   $(ZMQ_CFLAGS) $(SQLITE3_CFLAGS) $(UNIVALUE_CFLAGS) \
+  $(MYPP_CFLAGS) $(MARIADB_CFLAGS) \
   $(PROTOBUF_CFLAGS) $(GFLAGS_CFLAGS) $(GLOG_CFLAGS)
 libxayax_la_LIBADD = \
   $(XAYAUTIL_LIBS) \
   $(JSONCPP_LIBS) $(JSONRPCSERVER_LIBS) \
   $(ZMQ_LIBS) $(SQLITE3_LIBS) $(UNIVALUE_LIBS) \
+  $(MYPP_LIBS) $(MARIADB_LIBS) \
   $(PROTOBUF_LIBS) $(GFLAGS_LIBS) $(GLOG_LIBS) \
   -lstdc++fs
 libxayax_la_SOURCES = \
   basechain.cpp \
   blockcache.cpp \
   blockdata.cpp \
+  cache/mysql.cpp \
   controller.cpp \
   chainstate.cpp \
   database.cpp \
@@ -59,10 +62,12 @@ TESTS = tests
 tests_CXXFLAGS = \
   $(JSONCPP_CFLAGS) $(JSONRPCCLIENT_CFLAGS) \
   $(ZMQ_CFLAGS) $(SQLITE3_CFLAGS) $(GLOG_CFLAGS) \
+  $(MYPP_CFLAGS) $(MARIADB_CFLAGS) \
   $(GTEST_CFLAGS)
 tests_LDADD = $(builddir)/libxayax.la \
   $(JSONCPP_LIBS) $(JSONRPCCLIENT_LIBS) \
   $(ZMQ_LIBS) $(SQLITE3_LIBS) $(GLOG_LIBS) \
+  $(MYPP_LIBS) $(MARIADB_LIBS) \
   $(GTEST_LIBS) \
   -lstdc++fs
 check_HEADERS = testutils.hpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,6 +27,7 @@ libxayax_la_LIBADD = \
   -lstdc++fs
 libxayax_la_SOURCES = \
   basechain.cpp \
+  blockcache.cpp \
   blockdata.cpp \
   controller.cpp \
   chainstate.cpp \
@@ -39,6 +40,7 @@ libxayax_la_SOURCES = \
   $(PROTOSOURCES)
 xayax_HEADERS = \
   basechain.hpp \
+  blockcache.hpp \
   blockdata.hpp \
   controller.hpp \
   rpcutils.hpp
@@ -65,6 +67,7 @@ tests_LDADD = $(builddir)/libxayax.la \
   -lstdc++fs
 check_HEADERS = testutils.hpp
 tests_SOURCES = testutils.cpp \
+  blockcache_tests.cpp \
   blockdata_tests.cpp \
   chainstate_tests.cpp \
   controller_tests.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,27 +1,33 @@
 lib_LTLIBRARIES = libxayax.la
 xayaxdir = $(includedir)/xayax
 
-EXTRA_DIST = rpc-stubs/xaya.json
-
 RPC_STUBS = \
   rpc-stubs/xayarpcclient.h \
   rpc-stubs/xayarpcserverstub.h
-BUILT_SOURCES = $(RPC_STUBS)
-CLEANFILES = $(RPC_STUBS)
+
+PROTOS = \
+  proto/blockdata.proto
+PROTOHEADERS = $(PROTOS:.proto=.pb.h)
+PROTOSOURCES = $(PROTOS:.proto=.pb.cc)
+
+EXTRA_DIST = $(PROTOS) rpc-stubs/xaya.json
+BUILT_SOURCES = $(RPC_STUBS) $(PROTOHEADERS)
+CLEANFILES = $(RPC_STUBS) $(PROTOHEADERS) $(PROTOSOURCES)
 
 libxayax_la_CXXFLAGS = \
   $(XAYAUTIL_CFLAGS) \
   $(JSONCPP_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
   $(ZMQ_CFLAGS) $(SQLITE3_CFLAGS) $(UNIVALUE_CFLAGS) \
-  $(GFLAGS_CFLAGS) $(GLOG_CFLAGS)
+  $(PROTOBUF_CFLAGS) $(GFLAGS_CFLAGS) $(GLOG_CFLAGS)
 libxayax_la_LIBADD = \
   $(XAYAUTIL_LIBS) \
   $(JSONCPP_LIBS) $(JSONRPCSERVER_LIBS) \
   $(ZMQ_LIBS) $(SQLITE3_LIBS) $(UNIVALUE_LIBS) \
-  $(GFLAGS_LIBS) $(GLOG_LIBS) \
+  $(PROTOBUF_LIBS) $(GFLAGS_LIBS) $(GLOG_LIBS) \
   -lstdc++fs
 libxayax_la_SOURCES = \
   basechain.cpp \
+  blockdata.cpp \
   controller.cpp \
   chainstate.cpp \
   database.cpp \
@@ -29,7 +35,8 @@ libxayax_la_SOURCES = \
   pending.cpp \
   rpcutils.cpp \
   sync.cpp \
-  zmqpub.cpp
+  zmqpub.cpp \
+  $(PROTOSOURCES)
 xayax_HEADERS = \
   basechain.hpp \
   blockdata.hpp \
@@ -42,7 +49,7 @@ noinst_HEADERS = \
   private/pending.hpp \
   private/sync.hpp \
   private/zmqpub.hpp \
-  $(RPC_STUBS)
+  $(PROTOHEADERS) $(RPC_STUBS)
 
 check_PROGRAMS = tests
 TESTS = tests
@@ -58,6 +65,7 @@ tests_LDADD = $(builddir)/libxayax.la \
   -lstdc++fs
 check_HEADERS = testutils.hpp
 tests_SOURCES = testutils.cpp \
+  blockdata_tests.cpp \
   chainstate_tests.cpp \
   controller_tests.cpp \
   jsonutils_tests.cpp \
@@ -71,3 +79,6 @@ rpc-stubs/xayarpcclient.h: $(srcdir)/rpc-stubs/xaya.json
 	jsonrpcstub "$<" --cpp-client=XayaRpcClient --cpp-client-file="$@"
 rpc-stubs/xayarpcserverstub.h: $(srcdir)/rpc-stubs/xaya.json
 	jsonrpcstub "$<" --cpp-server=XayaRpcServerStub --cpp-server-file="$@"
+
+proto/%.pb.h proto/%.pb.cc: $(top_srcdir)/src/proto/%.proto
+	protoc -I$(top_srcdir) --cpp_out=$(top_builddir) "$<"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,7 @@ libxayax_la_SOURCES = \
   controller.cpp \
   chainstate.cpp \
   database.cpp \
+  jsonutils.cpp \
   pending.cpp \
   rpcutils.cpp \
   sync.cpp \
@@ -37,6 +38,7 @@ xayax_HEADERS = \
 noinst_HEADERS = \
   private/database.hpp \
   private/chainstate.hpp \
+  private/jsonutils.hpp \
   private/pending.hpp \
   private/sync.hpp \
   private/zmqpub.hpp \
@@ -58,6 +60,7 @@ check_HEADERS = testutils.hpp
 tests_SOURCES = testutils.cpp \
   chainstate_tests.cpp \
   controller_tests.cpp \
+  jsonutils_tests.cpp \
   pending_tests.cpp \
   rpcutils_tests.cpp \
   sync_tests.cpp \

--- a/src/basechain.hpp
+++ b/src/basechain.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2022 The Xaya developers
+// Copyright (C) 2021-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -62,7 +62,7 @@ public:
    * Sets a callbacks instance that will receive notifications about
    * new blocks and transactions.
    */
-  void SetCallbacks (Callbacks* c);
+  virtual void SetCallbacks (Callbacks* c);
 
   /**
    * Called after the instance is created and before it is getting used.

--- a/src/blockcache.cpp
+++ b/src/blockcache.cpp
@@ -1,0 +1,141 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockcache.hpp"
+
+#include <glog/logging.h>
+
+namespace xayax
+{
+
+/* ************************************************************************** */
+
+void
+BlockCacheChain::SetCallbacks (Callbacks* c)
+{
+  /* We forward the callbacks to the base implementation.  It will then
+     call TipChanged/PendingMoves on itself (rather than on this
+     instance) if things change, and thus those callbacks will get invoked
+     in that way.  */
+  base.SetCallbacks (c);
+}
+
+void
+BlockCacheChain::Start ()
+{
+  base.Start ();
+}
+
+bool
+BlockCacheChain::EnablePending ()
+{
+  return base.EnablePending ();
+}
+
+uint64_t
+BlockCacheChain::GetTipHeight ()
+{
+  lastTipHeight = base.GetTipHeight ();
+  return lastTipHeight;
+}
+
+std::vector<BlockData>
+BlockCacheChain::GetBlockRange (const uint64_t start, const uint64_t count)
+{
+  /* If this range is close to the tip, do not work with the cache at all
+     (neither try to query, as the blocks won't be there, nor store).  */
+  if (start + count + minDepth > lastTipHeight + 1)
+    {
+      VLOG (1)
+          << "Not using block cache for range "
+          << start << "+" << count
+          << " close to the tip @" << lastTipHeight;
+      return base.GetBlockRange (start, count);
+    }
+
+  /* Check if we have all blocks cached.  */
+  auto res = store.GetRange (start, count);
+  if (res.size () == count)
+    {
+      VLOG (1) << "All blocks for range " << start << "+" << count << " cached";
+      return res;
+    }
+
+  /* Otherwise, query the base chain, and save in the cache.  */
+  res = base.GetBlockRange (start, count);
+  store.Store (res);
+  VLOG (1) << "Stored range " << start << "+" << count << " in the cache";
+
+  return res;
+}
+
+int64_t
+BlockCacheChain::GetMainchainHeight (const std::string& hash)
+{
+  return base.GetMainchainHeight (hash);
+}
+
+std::vector<std::string>
+BlockCacheChain::GetMempool ()
+{
+  return base.GetMempool ();
+}
+
+bool
+BlockCacheChain::VerifyMessage (const std::string& msg,
+                                const std::string& signature,
+                                std::string& addr)
+{
+  return base.VerifyMessage (msg, signature, addr);
+}
+
+std::string
+BlockCacheChain::GetChain ()
+{
+  return base.GetChain ();
+}
+
+uint64_t
+BlockCacheChain::GetVersion ()
+{
+  return base.GetVersion ();
+}
+
+/* ************************************************************************** */
+
+void
+InMemoryBlockStorage::Store (const std::vector<BlockData>& blocks)
+{
+  for (const auto& blk : blocks)
+    data.emplace (blk.height, blk);
+}
+
+std::vector<BlockData>
+InMemoryBlockStorage::GetRange (const uint64_t start, const uint64_t count)
+{
+  /* Look for the starting height.  If we find it, go from there (as the
+     map is ordered) and see if we can get a consecutive range.  */
+  auto mit = data.find (start);
+  if (mit == data.end ())
+    return {};
+
+  std::vector<BlockData> res;
+  res.push_back (mit->second);
+
+  while (res.size () < count)
+    {
+      ++mit;
+      if (mit == data.end ())
+        return {};
+      if (mit->second.height != res.back ().height + 1)
+        return {};
+      res.push_back (mit->second);
+    }
+
+  return res;
+}
+
+/* ************************************************************************** */
+
+} // namespace xayax

--- a/src/blockcache.hpp
+++ b/src/blockcache.hpp
@@ -8,6 +8,7 @@
 #include "basechain.hpp"
 
 #include <map>
+#include <memory>
 
 namespace xayax
 {
@@ -123,6 +124,54 @@ public:
 
   void Store (const std::vector<BlockData>& blocks) override;
   std::vector<BlockData> GetRange (uint64_t start, uint64_t count) override;
+
+};
+
+/**
+ * An implementation of the BlockCacheChain::Storage that uses a MariaDB
+ * or MySQL database for storing and retrieving cached blocks.
+ */
+class MySqlBlockStorage : public BlockCacheChain::Storage
+{
+
+private:
+
+  class Implementation;
+
+  /**
+   * The implementation, which depends on the MariaDB connector library that
+   * is hidden from the public header here.
+   */
+  std::unique_ptr<Implementation> impl;
+
+public:
+
+  /**
+   * Opens a connection to the given MySQL server and uses it to cache
+   * the blocks.  Note that the right schema (see cache/mysql.cpp) must
+   * be set up already and the table exist.
+   */
+  MySqlBlockStorage (const std::string& host, unsigned port,
+                     const std::string& user, const std::string& password,
+                     const std::string& db, const std::string& tbl);
+
+  ~MySqlBlockStorage ();
+
+  void Store (const std::vector<BlockData>& blocks) override;
+  std::vector<BlockData> GetRange (uint64_t start, uint64_t count) override;
+
+  /**
+   * Helper function that parses a URL string into the components needed
+   * to construct a MySqlBlockStorage instance.  The string has the
+   * following form:
+   *    mysql://user:password@host:port/database/table
+   *
+   * Returns true if successful, false if the format is invalid.
+   */
+  static bool ParseUrl (const std::string& url,
+                        std::string& host, unsigned& port,
+                        std::string& user, std::string& password,
+                        std::string& db, std::string& tbl);
 
 };
 

--- a/src/blockcache.hpp
+++ b/src/blockcache.hpp
@@ -1,0 +1,131 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAX_BLOCKCACHE_HPP
+#define XAYAX_BLOCKCACHE_HPP
+
+#include "basechain.hpp"
+
+#include <map>
+
+namespace xayax
+{
+
+/**
+ * This is an implementation of BaseChain, which uses another BaseChain
+ * as "ground truth".  On top of that, it caches blocks seen to some storage
+ * (outside of the base-chain client), if they are behind tip by a certain
+ * depth (so assumed to be finalised).  When a call to GetBlockRange can
+ * be served from stored blocks, it is done instead of resorting back to
+ * the blockchain client.
+ *
+ * This class is implemented to ensure that no extra calls are made to
+ * the underlying blockchain client compared to using the underlying
+ * BaseChain directly, but that it avoids expensive GetBlockRange calls
+ * where it already retrieved those blocks previously.
+ */
+class BlockCacheChain : public BaseChain
+{
+
+public:
+
+  class Storage;
+
+private:
+
+  /** The underlying "ground truth" chain.  */
+  BaseChain& base;
+
+  /** The storage to use for block caching.  */
+  Storage& store;
+
+  /**
+   * Block depth behind tip before blocks are cached.  A block is cached
+   * if there are at least minDepth blocks following it in the chain.
+   */
+  const uint64_t minDepth;
+
+  /**
+   * The last tip height seen on the base chain.  We update this whenever
+   * GetTipHeight() is called (so as to not produce extra calls).  This
+   * happens frequently, as it is part of the sync steps.  The height
+   * here is used to judge whether or not a block is already far enough
+   * behind to be cached.
+   */
+  uint64_t lastTipHeight = 0;
+
+public:
+
+  explicit BlockCacheChain (BaseChain& b, Storage& s, const uint64_t md)
+    : base(b), store(s), minDepth(md)
+  {}
+
+  void SetCallbacks (Callbacks* c) override;
+
+  void Start () override;
+  bool EnablePending () override;
+  uint64_t GetTipHeight () override;
+  std::vector<BlockData> GetBlockRange (uint64_t start,
+                                        uint64_t count) override;
+  int64_t GetMainchainHeight (const std::string& hash) override;
+  std::vector<std::string> GetMempool () override;
+  bool VerifyMessage (const std::string& msg,
+                      const std::string& signature,
+                      std::string& addr) override;
+  std::string GetChain () override;
+  uint64_t GetVersion () override;
+
+};
+
+/**
+ * This is the interface for implementing storage of cached blocks.
+ * Each block stored is assumed to be finalised already, and so "should"
+ * never change again.
+ */
+class BlockCacheChain::Storage
+{
+
+public:
+
+  Storage () = default;
+  virtual ~Storage () = default;
+
+  /**
+   * Stores all of the given blocks into the cache.
+   */
+  virtual void Store (const std::vector<BlockData>& blocks) = 0;
+
+  /**
+   * Tries to retrieve blocks from the given range from storage.  If all
+   * of the blocks are cached, they should be returned in the right
+   * order.  Otherwise, a partial vector of the blocks that are known
+   * can be returned.
+   */
+  virtual std::vector<BlockData> GetRange (uint64_t start, uint64_t count) = 0;
+
+};
+
+/**
+ * This is an implementation of the BlockCacheChain::Storage interface,
+ * which stores blocks in memory.  This is obviously not very useful (or
+ * scalable) in production, but can be used for testing.
+ */
+class InMemoryBlockStorage : public BlockCacheChain::Storage
+{
+
+private:
+
+  /** The blocks stored, keyed by height.  */
+  std::map<uint64_t, BlockData> data;
+
+public:
+
+  void Store (const std::vector<BlockData>& blocks) override;
+  std::vector<BlockData> GetRange (uint64_t start, uint64_t count) override;
+
+};
+
+} // namespace xayax
+
+#endif // XAYAX_BLOCKCACHE_HPP

--- a/src/blockcache_tests.cpp
+++ b/src/blockcache_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 The Xaya developers
+// Copyright (C) 2023-2024 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,9 +6,13 @@
 
 #include "testutils.hpp"
 
+#include <mypp/tempdb.hpp>
+
+#include <glog/logging.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <sstream>
 
 namespace xayax
@@ -18,6 +22,39 @@ namespace
 
 using testing::ElementsAre;
 
+/** Environment variable holding the connection URL for the MySQL temp db.  */
+constexpr const char* TEMPDB_ENV = "MYPP_TEST_TEMPDB";
+
+/**
+ * Produces a BlockData instance for use in testing, which has the given
+ * height and a fake "hash" produced from the height.
+ */
+static BlockData
+GetBlock (const uint64_t height)
+{
+  std::ostringstream hash;
+  hash << "block " << height;
+
+  BlockData res;
+  res.height = height;
+  res.hash = hash.str ();
+
+  return res;
+}
+
+/**
+ * Produces a range of consecutive blocks as per GetBlock.
+ */
+static std::vector<BlockData>
+GetRange (const uint64_t start, const uint64_t count)
+{
+  std::vector<BlockData> res;
+  for (uint64_t h = start; h < start + count; ++h)
+    res.push_back (GetBlock (h));
+
+  return res;
+}
+
 /* ************************************************************************** */
 
 class InMemoryBlockStorageTests : public testing::Test
@@ -26,36 +63,6 @@ class InMemoryBlockStorageTests : public testing::Test
 protected:
 
   InMemoryBlockStorage store;
-
-  /**
-   * Produces a BlockData instance for use in testing, which has the given
-   * height and a fake "hash" produced from the height.
-   */
-  static BlockData
-  GetBlock (const uint64_t height)
-  {
-    std::ostringstream hash;
-    hash << "block " << height;
-
-    BlockData res;
-    res.height = height;
-    res.hash = hash.str ();
-
-    return res;
-  }
-
-  /**
-   * Produces a range of consecutive blocks as per GetBlock.
-   */
-  static std::vector<BlockData>
-  GetRange (const uint64_t start, const uint64_t count)
-  {
-    std::vector<BlockData> res;
-    for (uint64_t h = start; h < start + count; ++h)
-      res.push_back (GetBlock (h));
-
-    return res;
-  }
 
 };
 
@@ -115,7 +122,7 @@ protected:
    * Returns the "correct" range of blocks from our stored list.
    */
   std::vector<BlockData>
-  GetRange (const uint64_t start, const uint64_t count) const
+  GetStoredRange (const uint64_t start, const uint64_t count) const
   {
     std::vector<BlockData> res;
     for (uint64_t h = start; res.size () < count; ++h)
@@ -129,21 +136,21 @@ TEST_F (BlockCacheChainTests, UsesCacheWhenPossible)
 {
   /* These two retrieve the blocks from the base chain and store them
      into the cache.  */
-  EXPECT_EQ (chain.GetBlockRange (10, 5), GetRange (10, 5));
-  EXPECT_EQ (chain.GetBlockRange (20, 5), GetRange (20, 5));
+  EXPECT_EQ (chain.GetBlockRange (10, 5), GetStoredRange (10, 5));
+  EXPECT_EQ (chain.GetBlockRange (20, 5), GetStoredRange (20, 5));
   EXPECT_EQ (base.GetBlockRangeCalls (), 2);
 
   /* These calls use the cache.  */
-  EXPECT_EQ (chain.GetBlockRange (11, 2), GetRange (11, 2));
-  EXPECT_EQ (chain.GetBlockRange (20, 5), GetRange (20, 5));
+  EXPECT_EQ (chain.GetBlockRange (11, 2), GetStoredRange (11, 2));
+  EXPECT_EQ (chain.GetBlockRange (20, 5), GetStoredRange (20, 5));
   EXPECT_EQ (base.GetBlockRangeCalls (), 2);
 
   /* This has blocks that are not yet cached.  */
-  EXPECT_EQ (chain.GetBlockRange (15, 5), GetRange (15, 5));
+  EXPECT_EQ (chain.GetBlockRange (15, 5), GetStoredRange (15, 5));
   EXPECT_EQ (base.GetBlockRangeCalls (), 3);
 
   /* Now they are cached (the full range from 10 to 24).  */
-  EXPECT_EQ (chain.GetBlockRange (10, 15), GetRange (10, 15));
+  EXPECT_EQ (chain.GetBlockRange (10, 15), GetStoredRange (10, 15));
   EXPECT_EQ (base.GetBlockRangeCalls (), 3);
 }
 
@@ -156,18 +163,95 @@ TEST_F (BlockCacheChainTests, OnlyCachesAfterMinDepth)
   /* These ranges will be cached.  */
   for (unsigned i = 0; i < 2; ++i)
     {
-      EXPECT_EQ (chain.GetBlockRange (tip - 2, 1), GetRange (tip - 2, 1));
-      EXPECT_EQ (chain.GetBlockRange (tip - 12, 11), GetRange (tip - 12, 11));
+      EXPECT_EQ (chain.GetBlockRange (tip - 2, 1), GetStoredRange (tip - 2, 1));
+      EXPECT_EQ (chain.GetBlockRange (tip - 12, 11),
+                 GetStoredRange (tip - 12, 11));
       EXPECT_EQ (base.GetBlockRangeCalls (), 2);
     }
 
   /* These ranges end up too close to the tip.  */
   for (unsigned i = 0; i < 2; ++i)
     {
-      EXPECT_EQ (chain.GetBlockRange (tip - 1, 1), GetRange (tip - 1, 1));
-      EXPECT_EQ (chain.GetBlockRange (tip - 2, 2), GetRange (tip - 2, 2));
+      EXPECT_EQ (chain.GetBlockRange (tip - 1, 1), GetStoredRange (tip - 1, 1));
+      EXPECT_EQ (chain.GetBlockRange (tip - 2, 2), GetStoredRange (tip - 2, 2));
       EXPECT_EQ (base.GetBlockRangeCalls (), 4 + 2 * i);
     }
+}
+
+/* ************************************************************************** */
+
+class MySqlBlockStorageTests : public testing::Test
+{
+
+private:
+
+  /**
+   * Gets the URL to use for the temp db.
+   */
+  static std::string
+  GetTempDbUrl ()
+  {
+    const char* url = std::getenv (TEMPDB_ENV);
+    CHECK (url != nullptr)
+        << "Please set the environment variable '" << TEMPDB_ENV << "'"
+        << " to a MySQL URL for use in tests";
+    return url;
+  }
+
+protected:
+
+  mypp::TempDb db;
+  std::unique_ptr<MySqlBlockStorage> store;
+
+  MySqlBlockStorageTests ()
+    : db(GetTempDbUrl ())
+  {
+    db.Initialise ();
+    db.Get ().Execute (R"(
+      CREATE TABLE `cached_blocks` (
+        `height` BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+        `data` MEDIUMBLOB NOT NULL
+      );
+    )");
+
+    std::string host, user, password, db, tbl;
+    unsigned port;
+    CHECK (MySqlBlockStorage::ParseUrl (
+        GetTempDbUrl () + "/cached_blocks",
+        host, port, user, password, db, tbl));
+    store = std::make_unique<MySqlBlockStorage> (host, port, user, password,
+                                                 db, tbl);
+  }
+
+};
+
+TEST_F (MySqlBlockStorageTests, Parsing)
+{
+  std::string host, user, password, db, tbl;
+  unsigned port;
+
+  ASSERT_TRUE (MySqlBlockStorage::ParseUrl (
+      "mysql://domob:foo:bar@example.com:123/database/table",
+      host, port, user, password, db, tbl));
+  EXPECT_EQ (host, "example.com");
+  EXPECT_EQ (port, 123);
+  EXPECT_EQ (user, "domob");
+  EXPECT_EQ (password, "foo:bar");
+  EXPECT_EQ (db, "database");
+  EXPECT_EQ (tbl, "table");
+}
+
+TEST_F (MySqlBlockStorageTests, Storage)
+{
+  store->Store (GetRange (10, 30));
+  EXPECT_THAT (store->GetRange (10, 2),
+               ElementsAre (GetBlock (10), GetBlock (11)));
+  EXPECT_THAT (store->GetRange (15, 3),
+               ElementsAre (GetBlock (15), GetBlock (16), GetBlock (17)));
+  EXPECT_THAT (store->GetRange (39, 1), ElementsAre (GetBlock (39)));
+  EXPECT_THAT (store->GetRange (100, 2), ElementsAre ());
+  EXPECT_THAT (store->GetRange (8, 4),
+               ElementsAre (GetBlock (10), GetBlock (11)));
 }
 
 /* ************************************************************************** */

--- a/src/blockcache_tests.cpp
+++ b/src/blockcache_tests.cpp
@@ -1,0 +1,176 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockcache.hpp"
+
+#include "testutils.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+namespace xayax
+{
+namespace
+{
+
+using testing::ElementsAre;
+
+/* ************************************************************************** */
+
+class InMemoryBlockStorageTests : public testing::Test
+{
+
+protected:
+
+  InMemoryBlockStorage store;
+
+  /**
+   * Produces a BlockData instance for use in testing, which has the given
+   * height and a fake "hash" produced from the height.
+   */
+  static BlockData
+  GetBlock (const uint64_t height)
+  {
+    std::ostringstream hash;
+    hash << "block " << height;
+
+    BlockData res;
+    res.height = height;
+    res.hash = hash.str ();
+
+    return res;
+  }
+
+  /**
+   * Produces a range of consecutive blocks as per GetBlock.
+   */
+  static std::vector<BlockData>
+  GetRange (const uint64_t start, const uint64_t count)
+  {
+    std::vector<BlockData> res;
+    for (uint64_t h = start; h < start + count; ++h)
+      res.push_back (GetBlock (h));
+
+    return res;
+  }
+
+};
+
+TEST_F (InMemoryBlockStorageTests, RetrieveRange)
+{
+  store.Store (GetRange (10, 30));
+  EXPECT_THAT (store.GetRange (10, 2),
+               ElementsAre (GetBlock (10), GetBlock (11)));
+  EXPECT_THAT (store.GetRange (15, 3),
+               ElementsAre (GetBlock (15), GetBlock (16), GetBlock (17)));
+  EXPECT_THAT (store.GetRange (39, 1), ElementsAre (GetBlock (39)));
+}
+
+TEST_F (InMemoryBlockStorageTests, NotFullRangeInStore)
+{
+  /* Block 14 is not in the store.  */
+  store.Store (GetRange (10, 4));
+  store.Store (GetRange (15, 10));
+
+  EXPECT_THAT (store.GetRange (9, 1), ElementsAre ());
+  EXPECT_THAT (store.GetRange (14, 1), ElementsAre ());
+  EXPECT_THAT (store.GetRange (10, 5), ElementsAre ());
+  EXPECT_THAT (store.GetRange (25, 1), ElementsAre ());
+}
+
+/* ************************************************************************** */
+
+class BlockCacheChainTests : public testing::Test
+{
+
+private:
+
+  InMemoryBlockStorage store;
+
+protected:
+
+  TestBaseChain base;
+  BlockCacheChain chain;
+
+  /** Blocks on our chain.  */
+  std::vector<BlockData> blocks;
+
+  BlockCacheChainTests ()
+    : chain(base, store, 2)
+  {
+    blocks.push_back (base.SetGenesis (base.NewGenesis (0)));
+    for (unsigned i = 0; i < 100; ++i)
+      blocks.push_back (base.SetTip (base.NewBlock ()));
+
+    /* By calling GetTipHeight (as is usually done regularly by the sync
+       process), we make sure the block cache knows the current tip height
+       for matters of determining which blocks to cache.  */
+    EXPECT_EQ (chain.GetTipHeight (), blocks.back ().height);
+  }
+
+  /**
+   * Returns the "correct" range of blocks from our stored list.
+   */
+  std::vector<BlockData>
+  GetRange (const uint64_t start, const uint64_t count) const
+  {
+    std::vector<BlockData> res;
+    for (uint64_t h = start; res.size () < count; ++h)
+      res.push_back (blocks[h]);
+    return res;
+  }
+
+};
+
+TEST_F (BlockCacheChainTests, UsesCacheWhenPossible)
+{
+  /* These two retrieve the blocks from the base chain and store them
+     into the cache.  */
+  EXPECT_EQ (chain.GetBlockRange (10, 5), GetRange (10, 5));
+  EXPECT_EQ (chain.GetBlockRange (20, 5), GetRange (20, 5));
+  EXPECT_EQ (base.GetBlockRangeCalls (), 2);
+
+  /* These calls use the cache.  */
+  EXPECT_EQ (chain.GetBlockRange (11, 2), GetRange (11, 2));
+  EXPECT_EQ (chain.GetBlockRange (20, 5), GetRange (20, 5));
+  EXPECT_EQ (base.GetBlockRangeCalls (), 2);
+
+  /* This has blocks that are not yet cached.  */
+  EXPECT_EQ (chain.GetBlockRange (15, 5), GetRange (15, 5));
+  EXPECT_EQ (base.GetBlockRangeCalls (), 3);
+
+  /* Now they are cached (the full range from 10 to 24).  */
+  EXPECT_EQ (chain.GetBlockRange (10, 15), GetRange (10, 15));
+  EXPECT_EQ (base.GetBlockRangeCalls (), 3);
+}
+
+TEST_F (BlockCacheChainTests, OnlyCachesAfterMinDepth)
+{
+  /* The cache is set up to only consider block ranges that have at least
+     two more blocks confirming them.  */
+  const uint64_t tip = chain.GetTipHeight ();
+
+  /* These ranges will be cached.  */
+  for (unsigned i = 0; i < 2; ++i)
+    {
+      EXPECT_EQ (chain.GetBlockRange (tip - 2, 1), GetRange (tip - 2, 1));
+      EXPECT_EQ (chain.GetBlockRange (tip - 12, 11), GetRange (tip - 12, 11));
+      EXPECT_EQ (base.GetBlockRangeCalls (), 2);
+    }
+
+  /* These ranges end up too close to the tip.  */
+  for (unsigned i = 0; i < 2; ++i)
+    {
+      EXPECT_EQ (chain.GetBlockRange (tip - 1, 1), GetRange (tip - 1, 1));
+      EXPECT_EQ (chain.GetBlockRange (tip - 2, 2), GetRange (tip - 2, 2));
+      EXPECT_EQ (base.GetBlockRangeCalls (), 4 + 2 * i);
+    }
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace xayax

--- a/src/blockdata.cpp
+++ b/src/blockdata.cpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockdata.hpp"
+
+#include "private/jsonutils.hpp"
+#include "proto/blockdata.pb.h"
+
+#include <glog/logging.h>
+
+namespace xayax
+{
+
+std::ostream&
+operator<< (std::ostream& out, const MoveData& x)
+{
+  out << "Move " << x.txid << ":\n";
+  out << "  " << x.ns << "/" << x.name << "\n";
+  out << "  " << x.mv << "\n";
+  out << "  with " << x.burns.size () << " burns\n";
+  out << "  metadata:\n" << x.metadata;
+  return out;
+}
+
+std::string
+BlockData::Serialise () const
+{
+  /* We use protocol buffers internally to implement the serialisation,
+     but this is not exposed on the outside.  */
+
+  proto::Block blk;
+
+  blk.set_hash (hash);
+  blk.set_parent (parent);
+  blk.set_height (height);
+  blk.set_rngseed (rngseed);
+  blk.set_metadata (StoreJson (metadata));
+
+  for (const auto& mv : moves)
+    {
+      auto& mpb = *blk.add_moves ();
+      mpb.set_txid (mv.txid);
+      mpb.set_ns (mv.ns);
+      mpb.set_name (mv.name);
+      mpb.set_mv (mv.mv);
+      for (const auto& entry : mv.burns)
+        mpb.mutable_burns ()->insert ({entry.first, StoreJson (entry.second)});
+      CHECK_EQ (mpb.burns_size (), mv.burns.size ());
+      mpb.set_metadata (StoreJson (mv.metadata));
+    }
+
+  std::string res;
+  blk.SerializeToString (&res);
+  return res;
+}
+
+void
+BlockData::Deserialise (const std::string& data)
+{
+  proto::Block blk;
+  CHECK (blk.ParseFromString (data)) << "Failed to parse Block protocol buffer";
+
+  hash = blk.hash ();
+  parent = blk.parent ();
+  height = blk.height ();
+  rngseed = blk.rngseed ();
+  metadata = LoadJson (blk.metadata ());
+
+  moves.clear ();
+  for (const auto& mpb : blk.moves ())
+    {
+      moves.emplace_back ();
+      auto& mv = moves.back ();
+      mv.txid = mpb.txid ();
+      mv.ns = mpb.ns ();
+      mv.name = mpb.name ();
+      mv.mv = mpb.mv ();
+      mv.burns.clear ();
+      for (const auto& entry : mpb.burns ())
+        mv.burns.emplace (entry.first, LoadJson (entry.second));
+      CHECK_EQ (mv.burns.size (), mpb.burns_size ());
+      mv.metadata = LoadJson (mpb.metadata ());
+    }
+}
+
+} // namespace xayax

--- a/src/blockdata.hpp
+++ b/src/blockdata.hpp
@@ -73,16 +73,7 @@ struct MoveData
     return !(a == b);
   }
 
-  friend std::ostream&
-  operator<< (std::ostream& out, const MoveData& x)
-  {
-    out << "Move " << x.txid << ":\n";
-    out << "  " << x.ns << "/" << x.name << "\n";
-    out << "  " << x.mv << "\n";
-    out << "  with " << x.burns.size () << " burns\n";
-    out << "  metadata:\n" << x.metadata;
-    return out;
-  }
+  friend std::ostream& operator<< (std::ostream& out, const MoveData& x);
 
 };
 
@@ -124,6 +115,18 @@ struct BlockData
 
   BlockData& operator= (const BlockData&) = default;
   BlockData& operator= (BlockData&&) = default;
+
+  /**
+   * Serialises the BlockData instance to a string of bytes (e.g. for storing
+   * in a database).
+   */
+  std::string Serialise () const;
+
+  /**
+   * Deserialises from a string of bytes into this instance.  CHECK fails if
+   * there is an error.
+   */
+  void Deserialise (const std::string& data);
 
   friend bool operator== (const BlockData& a, const BlockData& b)
   {

--- a/src/blockdata_tests.cpp
+++ b/src/blockdata_tests.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockdata.hpp"
+
+#include "testutils.hpp"
+
+#include <gtest/gtest.h>
+
+namespace xayax
+{
+namespace
+{
+
+using BlockDataTests = testing::Test;
+
+TEST_F (BlockDataTests, RoundTrip)
+{
+  BlockData blk;
+  blk.hash = "block hash";
+  blk.parent = "parent hash";
+  blk.height = 42;
+  blk.rngseed = "abcdef";
+  blk.metadata = ParseJson (R"({"foo": "bar", "abc": [1, 2, 3]})");
+
+  MoveData m;
+  m.txid = "tx 1";
+  m.ns = "p";
+  m.name = "domob";
+  m.mv = R"({"x": 123})";
+  m.metadata = ParseJson (R"([1, 2, 3])");
+  m.burns = {
+    {"smc", ParseJson ("5.5")},
+    {"tn", ParseJson ("null")},
+    {"tftr", ParseJson (R"({"x": false})")},
+  };
+  blk.moves.push_back (m);
+
+  m.txid = "tx 2";
+  m.ns = "g";
+  m.name = "smc";
+  m.mv = R"({"mint": true})";
+  m.metadata = ParseJson ("null");
+  m.burns = {};
+  blk.moves.push_back (m);
+
+  BlockData blk2;
+  blk2.Deserialise (blk.Serialise ());
+  EXPECT_EQ (blk2, blk);
+}
+
+TEST_F (BlockDataTests, Invalid)
+{
+  BlockData blk;
+  EXPECT_DEATH (blk.Deserialise ("abc"), "Failed to parse");
+}
+
+} // anonymous namespace
+} // namespace xayax

--- a/src/cache/mysql.cpp
+++ b/src/cache/mysql.cpp
@@ -1,0 +1,209 @@
+// Copyright (C) 2023-2024 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockcache.hpp"
+
+#include <mypp/connection.hpp>
+#include <mypp/error.hpp>
+#include <mypp/statement.hpp>
+#include <mypp/url.hpp>
+
+#include <glog/logging.h>
+
+/* The MySQL cache stores blocks into a single table inside a given database,
+   which should be set up with a schema like this:
+
+   CREATE TABLE `cached_blocks` (
+      `height` BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+      `data` MEDIUMBLOB NOT NULL
+   );
+*/
+
+namespace xayax
+{
+
+/* ************************************************************************** */
+
+class MySqlBlockStorage::Implementation
+{
+
+private:
+
+  /** The underlying mypp connection.  */
+  mypp::Connection connection;
+
+  /** The name of the table to use.  */
+  std::string table;
+
+public:
+
+  Implementation () = default;
+
+  /**
+   * Opens the connection to the MySQL server.  Returns false if the connection
+   * fails.
+   */
+  bool Connect (const std::string& host, unsigned port,
+                const std::string& user, const std::string& password,
+                const std::string& db, const std::string& tbl);
+
+  /**
+   * Stores an array of blocks into the database.
+   */
+  void Store (const std::vector<BlockData>& blocks);
+
+  /**
+   * Retrieves a range of blocks, as far as they are in the cache.
+   */
+  std::vector<BlockData> GetRange (uint64_t start, uint64_t count);
+
+};
+
+bool
+MySqlBlockStorage::Implementation::Connect (
+    const std::string& host, const unsigned port,
+    const std::string& user, const std::string& password,
+    const std::string& db, const std::string& tbl)
+{
+  try
+    {
+      connection.Connect (host, port, user, password, db);
+      table = tbl;
+      LOG (INFO)
+          << "Connected to MySQL server at " << host
+          << " as user " << user << ", using table " << db << "." << tbl;
+      return true;
+    }
+  catch (const mypp::Error& exc)
+    {
+      LOG (ERROR) << exc.what ();
+      return false;
+    }
+}
+
+void
+MySqlBlockStorage::Implementation::Store (const std::vector<BlockData>& blocks)
+{
+  for (const auto& b : blocks)
+    {
+      mypp::Statement stmt(*connection);
+      try
+        {
+          stmt.Prepare (2, R"(
+            REPLACE INTO `)" + table + R"(`
+              (`height`, `data`) VALUES (?, ?)
+          )");
+        }
+      catch (const mypp::Error& exc)
+        {
+          LOG (FATAL) << exc.what ();
+        }
+
+      stmt.Bind<int64_t> (0, b.height);
+      stmt.BindBlob (1, b.Serialise ());
+
+      try
+        {
+          stmt.Execute ();
+        }
+      catch (const mypp::Error& exc)
+        {
+          LOG (WARNING) << exc.what ();
+          /* We continue here and try the next block.  It is not fatal
+             if one of them failed to insert for whatever reason.  */
+        }
+    }
+}
+
+std::vector<BlockData>
+MySqlBlockStorage::Implementation::GetRange (const uint64_t start,
+                                             const uint64_t count)
+{
+  mypp::Statement stmt(*connection);
+  try
+    {
+      stmt.Prepare (2, R"(
+        SELECT `data`
+          FROM `)" + table + R"(`
+          WHERE `height` >= ? AND `height` < ?
+          ORDER BY `height` ASC
+      )");
+    }
+  catch (const mypp::Error& exc)
+    {
+      LOG (FATAL) << exc.what ();
+    }
+
+  stmt.Bind<int64_t> (0, start);
+  stmt.Bind<int64_t> (1, start + count);
+
+  try
+    {
+      stmt.Query ();
+
+      std::vector<BlockData> res;
+      while (stmt.Fetch ())
+        {
+          res.emplace_back ();
+          res.back ().Deserialise (stmt.GetBlob ("data"));
+        }
+
+      return res;
+    }
+  catch (const mypp::Error& exc)
+    {
+      LOG (WARNING) << exc.what ();
+      return {};
+    }
+}
+
+/* ************************************************************************** */
+
+MySqlBlockStorage::MySqlBlockStorage (
+    const std::string& host, const unsigned port,
+    const std::string& user, const std::string& password,
+    const std::string& db, const std::string& tbl)
+{
+  impl = std::make_unique<Implementation> ();
+  CHECK (impl->Connect (host, port, user, password, db, tbl))
+      << "Failed to make MySQL connection";
+}
+
+MySqlBlockStorage::~MySqlBlockStorage () = default;
+
+void
+MySqlBlockStorage::Store (const std::vector<BlockData>& blocks)
+{
+  impl->Store (blocks);
+}
+
+std::vector<BlockData>
+MySqlBlockStorage::GetRange (const uint64_t start, const uint64_t count)
+{
+  return impl->GetRange (start, count);
+}
+
+bool
+MySqlBlockStorage::ParseUrl (const std::string& url,  
+                             std::string& host, unsigned& port,
+                             std::string& user, std::string& password,
+                             std::string& db, std::string& tbl)
+{
+  try
+    {
+      mypp::ParseUrl (url, host, port, user, password, db, tbl);
+      if (tbl.empty ())
+        return false;
+      return true;
+    }
+  catch (const mypp::Error& exc)
+    {
+      LOG (ERROR) << exc.what ();
+      return false;
+    }
+}
+
+/* ************************************************************************** */
+
+} // namespace xayax

--- a/src/jsonutils.cpp
+++ b/src/jsonutils.cpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2021-2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "private/jsonutils.hpp"
+
+#include <glog/logging.h>
+
+#include <sstream>
+
+namespace xayax
+{
+
+std::string
+StoreJson (const Json::Value& val)
+{
+  Json::StreamWriterBuilder wbuilder;
+  wbuilder["commentStyle"] = "None";
+  wbuilder["indentation"] = "";
+  wbuilder["enableYAMLCompatibility"] = false;
+  wbuilder["dropNullPlaceholders"] = false;
+  wbuilder["useSpecialFloats"] = false;
+
+  return Json::writeString (wbuilder, val);
+}
+
+Json::Value
+LoadJson (const std::string& str)
+{
+  Json::CharReaderBuilder rbuilder;
+  rbuilder["allowComments"] = false;
+  rbuilder["strictRoot"] = false;
+  rbuilder["failIfExtra"] = true;
+  rbuilder["rejectDupKeys"] = true;
+
+  Json::Value res;
+  std::string parseErrs;
+  std::istringstream in(str);
+  CHECK (Json::parseFromStream (rbuilder, in, &res, &parseErrs))
+      << "Invalid JSON stored: " << parseErrs << "\n" << str;
+
+  return res;
+}
+
+} // namespace xayax

--- a/src/jsonutils_tests.cpp
+++ b/src/jsonutils_tests.cpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "private/jsonutils.hpp"
+
+#include <gtest/gtest.h>
+
+namespace xayax
+{
+namespace
+{
+
+using JsonUtilsTests = testing::Test;
+
+TEST_F (JsonUtilsTests, RoundTrip)
+{
+  for (const std::string str : {"0", "\"abc\"", "[1,2,3]", "{\"foo\":42}"})
+    EXPECT_EQ (StoreJson (LoadJson (str)), str);
+}
+
+TEST_F (JsonUtilsTests, Invalid)
+{
+  EXPECT_DEATH (LoadJson ("foo"), "Invalid JSON stored");
+}
+
+} // anonymous namespace
+} // namespace xayax

--- a/src/private/database.hpp
+++ b/src/private/database.hpp
@@ -71,6 +71,11 @@ public:
    */
   Statement PrepareRo (const std::string& sql) const;
 
+  /**
+   * Returns the number of rows modified in the most recent update statement.
+   */
+  unsigned RowsModified () const;
+
 };
 
 /**
@@ -188,6 +193,11 @@ public:
     void Bind (int ind, const T& val);
 
   /**
+   * Binds a BLOB value (not TEXT as is otherwise done for std::string).
+   */
+  void BindBlob (int ind, const std::string& val);
+
+  /**
    * Checks if the numbered column is NULL in the current row.
    */
   bool IsNull (int ind) const;
@@ -198,6 +208,11 @@ public:
    */
   template <typename T>
     T Get (int ind) const;
+
+  /**
+   * Extracts a BLOB value as byte string.
+   */
+  std::string GetBlob (int ind) const;
 
 };
 

--- a/src/private/jsonutils.hpp
+++ b/src/private/jsonutils.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef XAYAX_JSONUTILS_HPP
+#define XAYAX_JSONUTILS_HPP
+
+#include <json/json.h>
+
+#include <string>
+
+namespace xayax
+{
+
+/**
+ * Converts a JSON value to a serialised string, in the way we do that for
+ * storing JSON into e.g. a database.
+ */
+std::string StoreJson (const Json::Value& val);
+
+/**
+ * Tries to parse JSON from a string that was stored in a database or otherwise
+ * saved with StoreJson previously.  CHECK fails if it is invalid.
+ */
+Json::Value LoadJson (const std::string& str);
+
+} // namespace xayax
+
+#endif // XAYAX_JSONUTILS_HPP

--- a/src/proto/.gitignore
+++ b/src/proto/.gitignore
@@ -1,0 +1,3 @@
+.dirstamp
+*.pb.h
+*.pb.cc

--- a/src/proto/blockdata.proto
+++ b/src/proto/blockdata.proto
@@ -1,0 +1,36 @@
+// Copyright (C) 2023 The Xaya developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+syntax = "proto3";
+
+package xayax.proto;
+
+/**
+ * Data about a move (name update) taking place in the blockchain.
+ * This is a "mirror" of the MoveData struct, able to carry and
+ * serialise all the data inside a MoveData.
+ */
+message Move
+{
+  string txid = 1;
+  string ns = 2;
+  string name = 3;
+  string mv = 4;
+  map<string, string> burns = 5;
+  string metadata = 6;
+}
+
+/**
+ * Basic data about a block, including its header and any relevant moves.
+ * This mimics the BlockData struct for serialisation.
+ */
+message Block
+{
+  string hash = 1;
+  string parent = 2;
+  uint64 height = 3;
+  string rngseed = 4;
+  string metadata = 5;
+  repeated Move moves = 6;
+}

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 The Xaya developers
+// Copyright (C) 2021-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -181,6 +181,13 @@ TestBaseChain::SetShouldThrow (const bool v)
   shouldThrow = v;
 }
 
+unsigned
+TestBaseChain::GetBlockRangeCalls () const
+{
+  std::lock_guard<std::mutex> lock(mut);
+  return getBlockRangeCalls;
+}
+
 void
 TestBaseChain::Start ()
 {
@@ -235,6 +242,8 @@ TestBaseChain::GetBlockRange (const uint64_t start, const uint64_t count)
   MaybeThrow ();
   std::lock_guard<std::mutex> lock(mut);
   std::vector<BlockData> res;
+
+  ++getBlockRangeCalls;
 
   for (uint64_t h = start; h < start + count; ++h)
     {

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 The Xaya developers
+// Copyright (C) 2021-2023 The Xaya developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -44,7 +44,7 @@ class TestBaseChain : public BaseChain
 private:
 
   /** Mutex for protecting the member fields.  */
-  std::mutex mut;
+  mutable std::mutex mut;
 
   /** Chain state with in-memory database for the tree structure.  */
   Chainstate chain;
@@ -82,6 +82,9 @@ private:
 
   /** If set to true, then implementation methods throw.  */
   bool shouldThrow = false;
+
+  /** How many times GetBlockRange has been called.  */
+  unsigned getBlockRangeCalls = 0;
 
   /**
    * Constructs a new block hash based on our counter.
@@ -150,6 +153,12 @@ public:
    * Turns errors to be thrown by implementation methods on or off.
    */
   void SetShouldThrow (bool v);
+
+  /**
+   * Returns how many times GetBlockRange has been called.  This is used
+   * to check that no unexpected calls happen when we use cached blocks.
+   */
+  unsigned GetBlockRangeCalls () const;
 
   void Start () override;
   bool EnablePending () override;


### PR DESCRIPTION
This implements optional "block caches":  Places (like an external database) that can store block data once retrieved from the base chain node, which can then be used to access it without burdening the blockchain node when they are used again (e.g. to resync a GSP).  As a first implementation, we provide a cache based on a MariaDB/MySQL database backend.

For this feature, we use (internally) protocol buffers to make the `BlockData` instances serialisable, and use that also for storing them in the internal SQLite database instead of storing all fields separately (simplifying the code).